### PR TITLE
Fit Track: Implementation of Weight History Graph

### DIFF
--- a/Bruno-Testing/Fitness Tracker/Audit/Audit History.bru
+++ b/Bruno-Testing/Fitness Tracker/Audit/Audit History.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:8080/api/v1/audit/{{entityId}}
+  url: {{baseUrl}}:8080/api/v1/audit/{{entityId}}
   body: none
   auth: bearer
 }

--- a/Bruno-Testing/Fitness Tracker/Customer/Add Customer.bru
+++ b/Bruno-Testing/Fitness Tracker/Customer/Add Customer.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://localhost:8080/api/v1/customers
+  url: {{baseUrl}}:8080/api/v1/customers
   body: json
   auth: none
 }

--- a/Bruno-Testing/Fitness Tracker/Customer/Get All Customers with Id.bru
+++ b/Bruno-Testing/Fitness Tracker/Customer/Get All Customers with Id.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:8080/api/v1/workouts/log/{{id}}
+  url: {{baseUrl}}:8080/api/v1/workouts/log/{{id}}
   body: none
   auth: bearer
 }

--- a/Bruno-Testing/Fitness Tracker/Customer/Get All Customers.bru
+++ b/Bruno-Testing/Fitness Tracker/Customer/Get All Customers.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:8080/api/v1/customers
+  url: {{baseUrl}}:8080/api/v1/customers
   body: none
   auth: bearer
 }

--- a/Bruno-Testing/Fitness Tracker/Customer/Get Customer By Id.bru
+++ b/Bruno-Testing/Fitness Tracker/Customer/Get Customer By Id.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:8080/api/v1/customers/{{id}}
+  url: {{baseUrl}}:8080/api/v1/customers/{{id}}
   body: none
   auth: bearer
 }

--- a/Bruno-Testing/Fitness Tracker/Customer/Update Customer.bru
+++ b/Bruno-Testing/Fitness Tracker/Customer/Update Customer.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 put {
-  url: http://localhost:8080/api/v1/customers/update/{{id}}
+  url: {{baseUrl}}:8080/api/v1/customers/update/{{id}}
   body: json
   auth: bearer
 }
@@ -15,17 +15,7 @@ auth:bearer {
 }
 
 body:json {
-  {
-    "name": "Ian Robinson",
-    "email": "ianrrob2@aol.com",
-    "age": 24,
-    "gender": "MALE",
-    "weight": 190,
-    "height": 71,
-    "weightGoal": 175,
-    "activity": "Active",
-    "bodyFat": 28
-  }
+  {"name":"Ian Robinson","email":"ianrrob2@aol.com","age":"24","gender":"Male","weight":"185","height":"71","weightGoal":"175","activity":"Advanced","bodyFat":"23"}
 }
 
 vars:pre-request {

--- a/Bruno-Testing/Fitness Tracker/Customer/Upload PFP.bru
+++ b/Bruno-Testing/Fitness Tracker/Customer/Upload PFP.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 put {
-  url: http://localhost:8080/api/v1/customers/{{id}}/profile-image
+  url: {{baseUrl}}:8080/api/v1/customers/{{id}}/profile-image
   body: multipartForm
   auth: bearer
 }

--- a/Bruno-Testing/Fitness Tracker/Login.bru
+++ b/Bruno-Testing/Fitness Tracker/Login.bru
@@ -12,8 +12,8 @@ post {
 
 body:json {
   {
-    "email": "ianrrob2@aol.com",
-    "password": "AAsup4602"
+    "email": "test123@gmail.com",
+    "password": "Test123"
   }
 }
 

--- a/Bruno-Testing/Fitness Tracker/Login.bru
+++ b/Bruno-Testing/Fitness Tracker/Login.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://localhost:8080/api/v1/auth/login
+  url: {{baseUrl}}:8080/api/v1/auth/login
   body: json
   auth: none
 }

--- a/Bruno-Testing/Fitness Tracker/Workout/Add Workout.bru
+++ b/Bruno-Testing/Fitness Tracker/Workout/Add Workout.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: http://localhost:8080/api/v1/workouts
+  url: {{baseUrl}}:8080/api/v1/workouts
   body: json
   auth: bearer
 }

--- a/Bruno-Testing/Fitness Tracker/Workout/Get All Workouts By Customer Id.bru
+++ b/Bruno-Testing/Fitness Tracker/Workout/Get All Workouts By Customer Id.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:8080/api/v1/workouts/log/{{customerId}}
+  url: {{baseUrl}}:8080/api/v1/workouts/log/{{customerId}}
   body: none
   auth: bearer
 }

--- a/Bruno-Testing/Fitness Tracker/Workout/Get All Workouts.bru
+++ b/Bruno-Testing/Fitness Tracker/Workout/Get All Workouts.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:8080/api/v1/workouts
+  url: {{baseUrl}}:8080/api/v1/workouts
   body: none
   auth: bearer
 }

--- a/Bruno-Testing/Fitness Tracker/Workout/Get Workout.bru
+++ b/Bruno-Testing/Fitness Tracker/Workout/Get Workout.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:8080/api/v1/workouts/{{id}}
+  url: {{baseUrl}}:8080/api/v1/workouts/{{id}}
   body: none
   auth: bearer
 }

--- a/Bruno-Testing/Fitness Tracker/environments/Fitness-Tracker.bru
+++ b/Bruno-Testing/Fitness Tracker/environments/Fitness-Tracker.bru
@@ -1,3 +1,0 @@
-vars {
-  authToken: eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOlsiUk9MRV9VU0VSIl0sInN1YiI6ImlhbnJyb2IyQGFvbC5jb20iLCJpc3MiOiJSb2JpbnNvbmlyIiwiaWF0IjoxNzM5NTk0NzAxLCJleHAiOjE3Mzk2ODExMDF9.HgOHXihj_bwwbjl2clTh-k3Lgy4VvmATmJ14KRYsI8A
-}

--- a/fit-track-ui/react/package-lock.json
+++ b/fit-track-ui/react/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.5.0",
         "echarts": "^5.5.1",
         "jwt-decode": "^3.1.2",
+        "moment": "^2.30.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.8.0",
@@ -3100,6 +3101,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/fit-track-ui/react/package.json
+++ b/fit-track-ui/react/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.5.0",
     "echarts": "^5.5.1",
     "jwt-decode": "^3.1.2",
+    "moment": "^2.30.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.8.0",

--- a/fit-track-ui/react/src/components/dashboard/Dashboard.tsx
+++ b/fit-track-ui/react/src/components/dashboard/Dashboard.tsx
@@ -10,6 +10,7 @@ import DurationWidget from "../widgets/workout-duration-visual/DurationWidget.ts
 import AverageInfoWidget from "../widgets/number-of-workouts/AverageInfoWidget.tsx";
 import WorkoutToCalories from "../widgets/workout-to-calories/WorkoutToCalories.tsx";
 import {isDateInThisWeek, sortWorkoutsAsc} from "../../utils/utilities.ts";
+import WeightHistory from "../widgets/weight-history-visual/WeightHistory.tsx";
 
 
 export const Dashboard = () => {
@@ -107,6 +108,7 @@ export const Dashboard = () => {
                     <div className="visual-content">
                         <CalorieWidget weekDate={selectedWeek.toString()}/>
                         <VolumeWidget weekDate={selectedWeek.toString()}/>
+                        <WeightHistory/>
                     </div>
                     <div>
                         <div className="minor-visual-content">

--- a/fit-track-ui/react/src/components/widgets/weight-history-visual/WeightHistory.tsx
+++ b/fit-track-ui/react/src/components/widgets/weight-history-visual/WeightHistory.tsx
@@ -1,0 +1,171 @@
+import React, {useEffect, useRef, useState} from "react";
+import {getCustomerWeightHistory} from "../../../services/client.ts";
+import * as echarts from "echarts";
+import moment from "moment";
+
+const WeightHistory = () => {
+    const chartInstance = useRef<any>(null);
+    const chartRef = useRef<HTMLDivElement>(null);
+    const hasAddedHeader = useRef(false);
+    const [monthSpan, setMonthSpan] = useState("one-month");
+    const [weightHistory, setWeightHistory] = useState<[string, any][]>([]);
+
+    useEffect(() => {
+        const fetchWeightData = async () => {
+            const customerEntityId = localStorage.getItem("customerId");
+            const res = await getCustomerWeightHistory(customerEntityId);
+            setWeightHistory(Object.entries(res.data));
+
+        };
+
+        fetchWeightData();
+    }, []);
+
+    useEffect(() => {
+        if (weightHistory.length === 0 && !hasAddedHeader.current) {
+            const noDataDom = document.getElementById("weight-history-graph");
+            const noDataText = document.createElement("h2");
+            noDataText.textContent = "No Weight History Available";
+            if (noDataDom) {
+                noDataDom.appendChild(noDataText);
+                hasAddedHeader.current = true;
+            }
+        }
+    });
+
+    const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        setMonthSpan(event.target.value);
+    };
+
+    const getMonthData = (span: string) => {
+        const data = [];
+        let days = 0;
+
+        if (span === "one-month") {
+            days = 29;
+        } else if (span === "three-months") {
+            days = 89;
+        } else if (span === "six-months") {
+            days = 179;
+        } else if (span === "year") {
+            days = 364;
+        }
+
+        for (let i = days; i >= 0; i--) {
+            const date = moment().subtract(i, "days");
+            data.push(date.format("YYYY-MM-D"));
+        }
+
+        return data;
+    };
+
+    const getWeightData = (weights: [string, any][], span: string) => {
+        const spanData = getMonthData(span);
+        const data: any[] = [];
+        let date;
+        let j = 0;
+
+        data.push([spanData[0], weights[j][0]]);
+        for (let i = 1; i < spanData.length - 1; i++) {
+            if (j >= weights.length) {
+                data.push([spanData[i], null]);
+            } else {
+                date = weights[j][1].toString();
+                const newDate = moment(date).format("YYYY-MM-D");
+
+                if (newDate === spanData[i]) {
+                    data.push([spanData[i], weights[j][0]]);
+                    j++;
+                } else {
+                    data.push([spanData[i], null]);
+                }
+            }
+        }
+        data.push([spanData[spanData.length - 1], weights[weights.length - 1][0]]);
+
+
+        return data;
+    };
+
+    useEffect(() => {
+        if (weightHistory.length !== 0 && chartRef.current) {
+            if (!chartInstance.current) {
+                chartInstance.current = echarts.init(chartRef.current);
+                hasAddedHeader.current = false;
+            }
+
+            chartInstance.current.setOption({
+                color: "whites",
+                title: {
+                    text: "Weight History",
+                    left: "center",
+                    textStyle: {
+                        color: "white",
+                    }
+                },
+                tooltip: {
+                    trigger: "axis"
+                },
+                calculable: true,
+                xAxis: {
+                    nameLocation: "middle",
+                    nameTextStyle: {
+                        color: "white"
+                    },
+                    type: "time",
+                    boundaryGap: false,
+                    axisLabel: {
+                        color: "white",
+                        formatter: (value: moment.MomentInput) => moment(value).format("MMM D"),
+                    },
+                    splitNumber: 5,
+                },
+                yAxis: {
+                    name: "Weight (lbs)",
+                    nameTextStyle: {
+                        color: "white"
+                    },
+                    axisLabel: {
+                        color: "white"
+                    }
+                },
+                series: [
+                    {
+                        type: "line",
+                        smooth: true,
+                        color: "#3f76c0",
+                        symbolSize: 7,
+                        data: getWeightData(weightHistory, monthSpan).map(val => val !== null ? val : undefined),
+                        connectNulls: true,
+                    }
+                ]
+            });
+        }
+
+        return () => {
+            if (chartInstance.current) {
+                chartInstance.current.dispose();
+                chartInstance.current = null;
+            }
+
+        };
+    }, [monthSpan, weightHistory]);
+
+    return (
+        <div>
+            <div className="visual-widget">
+                <div ref={chartRef} id="weight-history-graph" style={{width: "425px", height: "300px"}}/>
+                <div style={{textAlign: "center", marginTop: "10px"}}>
+                    <select style={{width: "120px", height: "30px", borderRadius: "4px"}} onChange={handleChange}>
+                        <option value="one-month">1 Month</option>
+                        <option value="three-months">3 Months</option>
+                        <option value="six-months">6 Months</option>
+                        <option value="year">1 Year</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default WeightHistory;

--- a/fit-track-ui/react/src/services/client.ts
+++ b/fit-track-ui/react/src/services/client.ts
@@ -27,14 +27,6 @@ axiosInstance.interceptors.request.use(
     }
 );
 
-export const getCustomers = async () => {
-    try {
-        return await axiosInstance.get("/api/v1/customers");
-    } catch (e) {
-        throw e;
-    }
-};
-
 export const getCustomer = async (id: any) => {
     try {
         return await axiosInstance.get(`/api/v1/customers/${id}`);
@@ -81,9 +73,10 @@ export const addWorkout = async (formData: any) => {
         throw e;
     }
 };
-export const deleteCustomer = async (id: any) => {
+
+export const getCustomerWeightHistory= async (entityId: any) => {
     try {
-        return await axiosInstance.delete(`/api/v1/customers/${id}`);
+        return await axiosInstance.get(`/api/v1/audit/${entityId}`);
     } catch (e) {
         throw e;
     }

--- a/fit-track/build.gradle.kts
+++ b/fit-track/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = "com.robinsonir"
-version = "1.1.1"
+version = "1.2.1"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/fit-track/src/main/java/com/robinsonir/fittrack/api/AuditHistoryController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/api/AuditHistoryController.java
@@ -22,6 +22,6 @@ public class AuditHistoryController {
 
     @GetMapping("{entityId}")
     public ResponseEntity<Map<Integer, OffsetDateTime>> getCustomerWeightAuditHistory(@PathVariable("entityId") Long entityId) {
-        return ResponseEntity.ok(auditHistoryService.getCustomerWeightAuditHistory(entityId));
+        return ResponseEntity.ok(auditHistoryService.getCustomerWeightHistory(entityId));
     }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/audit/AuditHistoryService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/audit/AuditHistoryService.java
@@ -20,17 +20,17 @@ public class AuditHistoryService {
         this.auditReader = auditReader;
     }
 
-    public Map<Integer, OffsetDateTime> getCustomerWeightAuditHistory(Long entityId) {
+    public Map<Integer, OffsetDateTime> getCustomerWeightHistory(Long entityId) {
         Map<Integer, OffsetDateTime> weightAudit = new HashMap<>();
         AuditQuery auditQuery = auditReader.createQuery()
-                .forRevisionsOfEntity(CustomerEntity.class, true, true)
-                .add(AuditEntity.id().eq(entityId));
+                .forRevisionsOfEntity(CustomerEntity.class, true,true)
+                .add(AuditEntity.id().eq(entityId))
+                .add(AuditEntity.property("weight").hasChanged());
+
         List items = auditQuery.getResultList();
         for (Object item : items) {
             CustomerEntity customer = (CustomerEntity) item;
-            if (customer.getWeight() != null && customer.getLastModifiedDate() != null) {
-                weightAudit.put(customer.getWeight(), customer.getLastModifiedDate());
-            }
+            weightAudit.put(customer.getWeight(), customer.getLastModifiedDate());
         }
 
         return weightAudit;

--- a/fit-track/src/main/resources/application.yml
+++ b/fit-track/src/main/resources/application.yml
@@ -75,6 +75,3 @@ logging:
     org.springframework.web.client: WARN
     org.springframework.ws: WARN
     sun.net.www.protocol: WARN
-  pattern:
-    console: "%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"  # Pattern for console logs
-

--- a/fit-track/src/test/java/com/robinsonir/fittrack/audit/AuditHistoryServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/audit/AuditHistoryServiceTest.java
@@ -58,7 +58,7 @@ class AuditHistoryServiceTest {
         when(auditQuery.add(any(AuditCriterion.class))).thenReturn(auditQuery);
         when(auditQuery.getResultList()).thenReturn(mockResults);
 
-        Map<Integer, OffsetDateTime> result = auditHistoryService.getCustomerWeightAuditHistory(entityId);
+        Map<Integer, OffsetDateTime> result = auditHistoryService.getCustomerWeightHistory(entityId);
 
         Map<Integer, OffsetDateTime> expected = new HashMap<>();
         expected.put(70, OffsetDateTime.parse("2024-01-01T10:00:00Z"));


### PR DESCRIPTION
<!-- Thank you for using the Fit Track pull request template. -->

# Fit Track: Implementation of Weight History Graph

## Description

The application now allows users to view their weight history over time. The history can be viewed from a time frame of one, three, six months, or a year from the current date.

## Changes

- Refactored implementation for retrieving weight auditing.
- Updated Bruno base url.
- Added weight graph to dashboard.
- updated login credentials for auth token in bruno

## Testing

- Previously, we could not view users' weight history and updates over time.
- Tested the graph by updating the weight over a few days.
- Now displays a line graph of weight depending on the selected time frame.


## Additional Comments

May need to add time frame "all" from the date the account was created to the current day.

# Checklist

- [x] All tests are passing
- [x] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly
