### PR TITLE
Fit Tracker: Node Downgrade Compatibility

### DIFF
--- a/fit-track-ui/react/Dockerfile
+++ b/fit-track-ui/react/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:18-alpine
 ARG api_base_url
 WORKDIR /app
 COPY package*.json .

--- a/fit-track-ui/react/package.json
+++ b/fit-track-ui/react/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "20.x"
+    "node": "18.x",
+    "npm": "9.x"
   },
   "scripts": {
     "start": "vite --host",

--- a/fit-track-ui/react/vite.config.ts
+++ b/fit-track-ui/react/vite.config.ts
@@ -6,9 +6,8 @@ export default defineConfig({
 
     plugins: [react(), tailwindcss()],
     server: {
+        host: "0.0.0.0",
+        port: 5173,
         allowedHosts: ["fitness-tracker-env.eba-3f5efq3k.us-east-1.elasticbeanstalk.com"],
-    },
-    build: {
-        minify: false, // Disable minification to avoid esbuild
     }
 });


### PR DESCRIPTION
<!-- Thank you for using the Fit Track pull request template. -->

# Fit Track: Node Downgrade Compatibility

## Description

The `fit-track_node_version` branch contains infrastructure and build configuration changes focused on resolving deployment and build optimization issues by downgrading the Node.js version and adjusting Vite build configurations for better Elastic Beanstalk compatibility.


## Changes

1. **Fit Tracker: downgrade to node 18**
    - **Node.js version downgrade**: Changed from Node.js 20 to Node.js 18
        - Updated `Dockerfile`: `FROM node:20-alpine` → `FROM node:18-alpine`
        - Updated engines: `"node": "20.x"` → `"node": "18.x"` `package.json`
        - Added npm version constraint: `"npm": "9.x"`

    - **Vite server configuration**: Added explicit host and port settings
        - Added `host: "0.0.0.0"` for container compatibility
        - Added `port: 5173` for consistent development setup

    - **Build optimization cleanup**: Removed `build.minify: false` setting

2. **Fit Tracker: enable optimizations** 
    - **Re-enabled Vite optimizations**: Removed the `optimizeDeps` configuration that was disabling dependency optimization
    - **Maintained build settings**: Kept `minify: false` to avoid esbuild issues

3. **Fit Tracker: disable esbuild optimizations** 
    - **Disabled dependency optimization**: Added `optimizeDeps` configuration with:
        - `noDiscovery: true` - Disables automatic dependency discovery
        - `include: []` - Empty array to prevent pre-bundling

    - **Disabled minification**: Added `minify: false` to avoid esbuild platform-specific binary issues


## Testing

- *Describe what the old behavior is and what the new behavior is.*

## Additional Comments

- *(Optional) Anything else that you may want to add.*

# Checklist

- [x] All tests are passing
- [x] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly
