### PR TITLE
FTRACK-2: Replace Member Age Field with Date of Birth

### DIFF
--- a/Bruno/Fitness Tracker/Audit/Get Weight Trend.bru
+++ b/Bruno/Fitness Tracker/Audit/Get Weight Trend.bru
@@ -15,7 +15,7 @@ params:path {
 }
 
 auth:bearer {
-  token: {{authToken}}
+  token: {{bearerToken}}
 }
 
 vars:pre-request {

--- a/Bruno/Fitness Tracker/Login and Get Token.bru
+++ b/Bruno/Fitness Tracker/Login and Get Token.bru
@@ -1,5 +1,5 @@
 meta {
-  name: Login
+  name: Login and Get Token
   type: http
   seq: 2
 }
@@ -18,5 +18,5 @@ body:json {
 }
 
 script:post-response {
-  bru.setEnvVar("authToken", res.getBody().jwtToken)
+  bru.setEnvVar("bearerToken", res.getBody().jwtToken)
 }

--- a/Bruno/Fitness Tracker/Member/Add Member.bru
+++ b/Bruno/Fitness Tracker/Member/Add Member.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{baseUrl}}:8080/api/v1/Members
+  url: {{baseUrl}}:8080/api/v1/members
   body: json
   auth: none
 }
@@ -15,7 +15,7 @@ body:json {
       "name":"Test Acc",
       "email":"test123@gmail.com",
       "password":"Test123",
-      "age":"21",
-      "gender":"Male"
+      "dateOfBirth":"1999-01-01",
+      "gender":"Forbidden"
   }
 }

--- a/Bruno/Fitness Tracker/Member/Get Member By Id.bru
+++ b/Bruno/Fitness Tracker/Member/Get Member By Id.bru
@@ -11,9 +11,9 @@ get {
 }
 
 params:path {
-  memberId: 1
+  memberId: 6
 }
 
 auth:bearer {
-  token: {{authToken}}
+  token: {{bearerToken}}
 }

--- a/Bruno/Fitness Tracker/Member/Return Authenticated Member.bru
+++ b/Bruno/Fitness Tracker/Member/Return Authenticated Member.bru
@@ -1,11 +1,11 @@
 meta {
-  name: Get All Workouts
+  name: Return Authenticated Member
   type: http
-  seq: 1
+  seq: 6
 }
 
 get {
-  url: {{baseUrl}}:8080/api/v1/workouts
+  url: {{baseUrl}}:8080/api/v1/members/me
   body: none
   auth: bearer
 }

--- a/Bruno/Fitness Tracker/Member/Update Member.bru
+++ b/Bruno/Fitness Tracker/Member/Update Member.bru
@@ -15,7 +15,7 @@ params:path {
 }
 
 auth:bearer {
-  token: {{authToken}}
+  token: {{bearerToken}}
 }
 
 body:json {

--- a/Bruno/Fitness Tracker/Member/Upload PFP.bru
+++ b/Bruno/Fitness Tracker/Member/Upload PFP.bru
@@ -15,7 +15,7 @@ params:path {
 }
 
 auth:bearer {
-  token: {{authToken}}
+  token: {{bearerToken}}
 }
 
 body:multipart-form {

--- a/Bruno/Fitness Tracker/Workout/Add Workout.bru
+++ b/Bruno/Fitness Tracker/Workout/Add Workout.bru
@@ -11,7 +11,7 @@ post {
 }
 
 auth:bearer {
-  token: {{authToken}}
+  token: {{bearerToken}}
 }
 
 body:json {

--- a/Bruno/Fitness Tracker/Workout/Delete Workout.bru
+++ b/Bruno/Fitness Tracker/Workout/Delete Workout.bru
@@ -11,7 +11,7 @@ delete {
 }
 
 auth:bearer {
-  token: {{authToken}}
+  token: {{bearerToken}}
 }
 
 vars:pre-request {

--- a/Bruno/Fitness Tracker/Workout/Get All Workouts By Customer Id.bru
+++ b/Bruno/Fitness Tracker/Workout/Get All Workouts By Customer Id.bru
@@ -15,5 +15,5 @@ params:path {
 }
 
 auth:bearer {
-  token: {{authToken}}
+  token: {{bearerToken}}
 }

--- a/Bruno/Fitness Tracker/Workout/Get Workout.bru
+++ b/Bruno/Fitness Tracker/Workout/Get Workout.bru
@@ -5,15 +5,15 @@ meta {
 }
 
 get {
-  url: {{baseUrl}}:8080/api/v1/workouts/{{id}}
+  url: {{baseUrl}}:8080/api/v1/workouts/:id
   body: none
   auth: bearer
 }
 
-auth:bearer {
-  token: {{authToken}}
+params:path {
+  id: 9
 }
 
-vars:pre-request {
-  id: 9
+auth:bearer {
+  token: {{bearerToken}}
 }

--- a/Bruno/Fitness Tracker/environments/Fitness-Tracker-Dev.bru
+++ b/Bruno/Fitness Tracker/environments/Fitness-Tracker-Dev.bru
@@ -1,4 +1,6 @@
 vars {
-  authToken: eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOlsiUk9MRV9VU0VSIl0sInN1YiI6ImlhbnJyb2IyQGFvbC5jb20iLCJpc3MiOiJSb2JpbnNvbmlyIiwiaWF0IjoxNzM5NTk0NzAxLCJleHAiOjE3Mzk2ODExMDF9.HgOHXihj_bwwbjl2clTh-k3Lgy4VvmATmJ14KRYsI8A
   baseUrl: http://fit-track-dev.eba-jpnjhwum.us-east-1.elasticbeanstalk.com
 }
+vars:secret [
+  bearerToken
+]

--- a/Bruno/Fitness Tracker/environments/Fitness-Tracker-Local.bru
+++ b/Bruno/Fitness Tracker/environments/Fitness-Tracker-Local.bru
@@ -1,4 +1,6 @@
 vars {
-  authToken: eyJhbGciOiJIUzI1NiJ9.eyJzY29wZXMiOlsiUk9MRV9VU0VSIl0sInN1YiI6ImlhbnJyb2IyQGFvbC5jb20iLCJpc3MiOiJSb2JpbnNvbmlyIiwiaWF0IjoxNzM5NTk0NzAxLCJleHAiOjE3Mzk2ODExMDF9.HgOHXihj_bwwbjl2clTh-k3Lgy4VvmATmJ14KRYsI8A
   baseUrl: http://localhost
 }
+vars:secret [
+  bearerToken
+]

--- a/fit-track-ui/react/package-lock.json
+++ b/fit-track-ui/react/package-lock.json
@@ -40,9 +40,11 @@
         "@types/react": "^18.2.20",
         "@types/react-dom": "^18.2.7",
         "@vitejs/plugin-react": "^4.7.0",
+        "@vitest/ui": "^4.1.5",
         "autoprefixer": "^10.4.21",
         "cssnano": "^7.0.6",
         "globals": "^16.2.0",
+        "jsdom": "^29.1.1",
         "markdownlint-cli": "^0.48.0",
         "orval": "^7.13.2",
         "postcss": "^8.5.5",
@@ -58,7 +60,8 @@
         "stylelint": "^16.20.0",
         "stylelint-config-standard": "^38.0.0",
         "stylelint-config-tailwindcss": "^1.0.0",
-        "vite": "^6.4.2"
+        "vite": "^6.4.2",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": "22.x",
@@ -172,6 +175,193 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -473,6 +663,40 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@bramus/specificity/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@bramus/specificity/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@csstools/cascade-layer-name-parser": {
       "version": "2.0.5",
@@ -2085,6 +2309,24 @@
         "url": "https://eslint.org/donate"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@exodus/schemasafe": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
@@ -2249,9 +2491,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -2792,6 +3034,13 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
@@ -3713,6 +3962,13 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -4664,6 +4920,17 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -4673,6 +4940,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/es-aggregate-error": {
       "version": "1.0.6",
@@ -4821,6 +5095,141 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
+      "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "fflate": "^0.8.2",
+        "flatted": "^3.4.2",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.5"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abort-controller": {
@@ -5028,6 +5437,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -5155,6 +5574,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -5363,6 +5792,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5901,6 +6340,58 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -5972,6 +6463,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
@@ -6435,6 +6933,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -6569,6 +7074,16 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6619,6 +7134,16 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/expr-eval-fork": {
       "version": "3.0.3",
@@ -6711,6 +7236,13 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "10.1.1",
@@ -7236,6 +7768,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-tags": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
@@ -7710,6 +8255,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7939,6 +8491,141 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/jsep": {
@@ -8525,12 +9212,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-it": {
@@ -9414,6 +10101,16 @@
         "node": "*"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9744,6 +10441,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -9950,6 +10658,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -9986,6 +10720,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -11989,6 +12730,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -12210,6 +12964,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -12221,6 +12982,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/slash": {
@@ -12282,6 +13058,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -12745,6 +13535,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -12843,6 +13640,23 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -12888,6 +13702,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -12899,6 +13743,29 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -13141,6 +14008,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -13376,6 +14253,122 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
@@ -13388,6 +14381,16 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -13499,6 +14502,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -13530,6 +14550,23 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/fit-track-ui/react/package.json
+++ b/fit-track-ui/react/package.json
@@ -16,7 +16,9 @@
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint src --ext .js,.jsx,.ts,.tsx --fix",
     "lint:css": "stylelint \"**/*.css\"",
-    "lint:md": "markdownlint '**/*.md' --ignore .git --ignore node_modules"
+    "lint:md": "markdownlint '**/*.md' --ignore .git --ignore node_modules",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -51,9 +53,11 @@
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.7",
     "@vitejs/plugin-react": "^4.7.0",
+    "@vitest/ui": "^4.1.5",
     "autoprefixer": "^10.4.21",
     "cssnano": "^7.0.6",
     "globals": "^16.2.0",
+    "jsdom": "^29.1.1",
     "markdownlint-cli": "^0.48.0",
     "orval": "^7.13.2",
     "postcss": "^8.5.5",
@@ -69,6 +73,7 @@
     "stylelint": "^16.20.0",
     "stylelint-config-standard": "^38.0.0",
     "stylelint-config-tailwindcss": "^1.0.0",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^4.1.5"
   }
 }

--- a/fit-track-ui/react/src/components/features/signup/SignUp.tsx
+++ b/fit-track-ui/react/src/components/features/signup/SignUp.tsx
@@ -3,23 +3,13 @@ import {useNavigate} from "react-router-dom";
 import {Gender} from "../../../api/generated/models";
 import {useAuth} from "../../../context/AuthContext.tsx";
 
+const todayISO = () => new Date().toISOString().slice(0, 10);
+
 export const SignUp = () => {
     const navigate = useNavigate();
     const {register} = useAuth();
 
     const [signUpError, setSignUpError] = useState<string | null>(null);
-
-    const generateAgeOptions = () => {
-        const options = [];
-        for (let age = 18; age <= 80; age++) {
-            options.push(
-                <option key={age} value={age}>
-                    {age}
-                </option>
-            );
-        }
-        return options;
-    };
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -30,8 +20,8 @@ export const SignUp = () => {
             name: data.get("name") as string,
             email: data.get("email") as string,
             password: data.get("password") as string,
-            age: Number(data.get("age")),
-            gender: data.get("gender") as Gender,
+            dateOfBirth: data.get("dateOfBirth") as string,
+            gender: data.get("gender") as Gender
         };
 
         try {
@@ -63,37 +53,32 @@ export const SignUp = () => {
                             <div className="space-y-2">
                                 <label htmlFor="name">Full Name</label>
                                 <input name="name" type="text"
-                                    className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                       className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                             </div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                             <div className="space-y-2">
                                 <label htmlFor="email">Email</label>
                                 <input name="email" type="email"
-                                    className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                       className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                             </div>
                             <div className="space-y-2">
                                 <label htmlFor="password">Password</label>
                                 <input name="password" type="password" minLength={6}
-                                    className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                       className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                             </div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <div className="space-y-2">
-                                <label htmlFor="age">Age</label>
-                                <select className="border-2 border-gray-600 rounded-md p-2 w-full" name="age"
-                                    aria-label="Select age"
-                                    title="Select age"
-                                    required>
-                                    <option value="">Select age</option>
-                                    {generateAgeOptions()}
-                                </select>
+                                <label htmlFor="age">Date of Birth</label>
+                                <input className="border-2 border-gray-600 rounded-md p-2 mt-3 w-full" name="dateOfBirth"
+                                       type="date" max={todayISO()} min="1900-01-01" required/>
                             </div>
                             <div className="space-y-2">
                                 <label htmlFor="gender">Gender</label>
                                 <select className="border-2 border-gray-600 rounded-md p-2 w-full" name="gender"
-                                    title="Select gender"
-                                    required>
+                                        title="Select gender"
+                                        required>
                                     <option value="">Select gender</option>
                                     <option value="Male">Male</option>
                                     <option value="Female">Female</option>
@@ -102,7 +87,7 @@ export const SignUp = () => {
                             </div>
                         </div>
                         <button type="submit"
-                            className="w-full h-12 bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-2 rounded-md cursor-pointer">Sign
+                                className="w-full h-12 bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-2 rounded-md cursor-pointer">Sign
                             Up
                         </button>
                     </form>

--- a/fit-track-ui/react/src/components/features/signup/SignUp.tsx
+++ b/fit-track-ui/react/src/components/features/signup/SignUp.tsx
@@ -53,32 +53,32 @@ export const SignUp = () => {
                             <div className="space-y-2">
                                 <label htmlFor="name">Full Name</label>
                                 <input name="name" type="text"
-                                       className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                    className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                             </div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                             <div className="space-y-2">
                                 <label htmlFor="email">Email</label>
                                 <input name="email" type="email"
-                                       className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                    className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                             </div>
                             <div className="space-y-2">
                                 <label htmlFor="password">Password</label>
                                 <input name="password" type="password" minLength={6}
-                                       className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                    className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                             </div>
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <div className="space-y-2">
                                 <label htmlFor="age">Date of Birth</label>
                                 <input className="border-2 border-gray-600 rounded-md p-2 mt-3 w-full" name="dateOfBirth"
-                                       type="date" max={todayISO()} min="1900-01-01" required/>
+                                    type="date" max={todayISO()} min="1900-01-01" required/>
                             </div>
                             <div className="space-y-2">
                                 <label htmlFor="gender">Gender</label>
                                 <select className="border-2 border-gray-600 rounded-md p-2 w-full" name="gender"
-                                        title="Select gender"
-                                        required>
+                                    title="Select gender"
+                                    required>
                                     <option value="">Select gender</option>
                                     <option value="Male">Male</option>
                                     <option value="Female">Female</option>
@@ -87,7 +87,7 @@ export const SignUp = () => {
                             </div>
                         </div>
                         <button type="submit"
-                                className="w-full h-12 bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-2 rounded-md cursor-pointer">Sign
+                            className="w-full h-12 bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-2 rounded-md cursor-pointer">Sign
                             Up
                         </button>
                     </form>

--- a/fit-track-ui/react/src/context/AuthContext.tsx
+++ b/fit-track-ui/react/src/context/AuthContext.tsx
@@ -18,19 +18,33 @@ type AuthContextType = {
 const AuthContext = createContext<AuthContextType | null>(null);
 
 const AuthProvider = ({children}: { children: any }) => {
-    const {me: fetchMe} = useMemo(() => getMemberApi(), []);
-    const {registerMember} = useMemo(() => getMemberApi(), []);
+    const {me: fetchMe, registerMember} = useMemo(() => getMemberApi(), []);
     const {login: performLogin} = getAuthApi();
     const [member, setMember] = useState<MemberDTO | undefined>();
 
     const refreshMember = async (): Promise<void> => {
-        const fresh = await fetchMe();
-        setMember(fresh);
+        const freshMember = await fetchMe();
+        setMember(freshMember);
     };
 
     useEffect(() => {
-        if (localStorage.getItem("access_token") && isMemberAuthenticated()) {
-            refreshMember().catch(logOut);
+        const token = localStorage.getItem("access_token");
+        if (!token) return;
+
+        try {
+            const decoded = jwtDecode<JwtPayload>(token);
+            if (!decoded.exp || Date.now() > decoded.exp * 1000) return;
+
+            fetchMe()
+                .then(setMember)
+                .catch(() => {
+                    localStorage.removeItem("access_token");
+                    setMember(undefined);
+                    window.location.href = "/login";
+                });
+        } catch {
+            localStorage.removeItem("access_token");
+            window.location.href = "/login";
         }
     }, [fetchMe]);
 
@@ -78,11 +92,7 @@ const AuthProvider = ({children}: { children: any }) => {
             return false;
         }
         const expiration = decodeToken.exp;
-        if (Date.now() > expiration * 1000) {
-            logOut();
-            return false;
-        }
-        return true;
+        return Date.now() <= expiration * 1000;
     };
 
     return (

--- a/fit-track-ui/react/src/context/AuthContext.tsx
+++ b/fit-track-ui/react/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ type AuthContextType = {
     register: (req: MemberRegistrationRequest) => Promise<void>;
     logOut: () => void;
     isMemberAuthenticated: () => boolean;
+    refreshMember: () => Promise<void>;
 };
 
 
@@ -22,9 +23,14 @@ const AuthProvider = ({children}: { children: any }) => {
     const {login: performLogin} = getAuthApi();
     const [member, setMember] = useState<MemberDTO | undefined>();
 
+    const refreshMember = async (): Promise<void> => {
+        const fresh = await fetchMe();
+        setMember(fresh);
+    };
+
     useEffect(() => {
         if (localStorage.getItem("access_token") && isMemberAuthenticated()) {
-            fetchMe().then(setMember).catch(logOut);
+            refreshMember().catch(logOut);
         }
     }, [fetchMe]);
 
@@ -86,6 +92,7 @@ const AuthProvider = ({children}: { children: any }) => {
             register: register,
             logOut,
             isMemberAuthenticated,
+            refreshMember,
         }}>
             {children}
         </AuthContext.Provider>

--- a/fit-track-ui/react/src/pages/profile/Profile.tsx
+++ b/fit-track-ui/react/src/pages/profile/Profile.tsx
@@ -5,14 +5,19 @@ import {getWorkoutsApi} from "../../api/generated/endpoints/workouts-api/workout
 import {buildProfileImage} from "../../services/client.ts";
 import {toast} from "sonner";
 import {authenticatedMember} from "../layout.tsx";
+import {useAuth} from "../../context/AuthContext.tsx";
 
 
 export const Profile = () => {
     const member = authenticatedMember();
+    const {refreshMember} = useAuth();
     const [workoutData, setWorkoutData] = useState<WorkoutDTO[]>([]);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const dobInputRef = useRef<HTMLInputElement>(null);
     const {updateMember, uploadMemberProfileImage} = getMemberApi();
     const {getAllWorkoutsByMemberId} = getWorkoutsApi();
+    const [isEditable, setIsEditable] = useState(false);
+    const [pendingDob, setPendingDob] = useState<string | null>(null);
 
     useEffect(() => {
         const fetchData = async () => {
@@ -31,6 +36,16 @@ export const Profile = () => {
         return <div>Loading...</div>;
     }
 
+    const calculateAge = (dateOfBirth: string) => {
+        const today = new Date();
+        const birthDate = new Date(dateOfBirth);
+        let age = today.getFullYear() - birthDate.getFullYear();
+        const monthDifference = today.getMonth() - birthDate.getMonth();
+        if (monthDifference < 0 || (monthDifference === 0 && today.getDate() < birthDate.getDate())) {
+            age--;
+        }
+        return age;
+    }
     const profile = {
         name: member.name,
         email: member.email,
@@ -38,7 +53,7 @@ export const Profile = () => {
     };
 
     const healthInfo = {
-        age: member.age,
+        age: calculateAge(member.dateOfBirth),
         gender: member.gender,
         weight: member.weight,
         height: member.height,
@@ -85,15 +100,31 @@ export const Profile = () => {
         }
     };
 
+    const saveDob = async (dateOfBirth: string) => {
+        if (!member.id) return;
+        try {
+            await updateMember(member.id, {dateOfBirth});
+            toast.success("Date of Birth updated successfully!");
+            setPendingDob(null);
+            await refreshMember();
+        } catch (error) {
+            console.error("Failed to update member.", error);
+            toast.error("Failed to update date of birth.");
+        }
+    }
+
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+        if (!isEditable) {
+            setIsEditable(true);
+            return;
+        }
         const formData = new FormData(e.currentTarget);
         formData.append("name", formData.get("firstName") + " " + formData.get("lastName"));
 
         const update: MemberUpdateRequest = {
             name: String(formData.get("name")),
             email: formData.get("email") as string,
-            age: Number(formData.get("age")) || undefined,
             gender: formData.get("gender") as Gender,
             weight: Number(formData.get("weight")) || undefined,
             height: Number(formData.get("height")) || undefined,
@@ -106,6 +137,7 @@ export const Profile = () => {
             try {
                 await updateMember(member.id, update);
                 toast.success("Profile updated successfully!");
+                setIsEditable(false);
             } catch (error) {
                 console.error("Failed to update member.", error);
                 toast.error("Failed to update profile.");
@@ -126,7 +158,7 @@ export const Profile = () => {
                     <div className="flex flex-col items-center">
                         <div className="w-24 h-24 mb-4 relative">
                             <img className="rounded-[50%] object-cover w-20 h-20 z-1"
-                                src={pfp} alt="pfp"/>
+                                 src={pfp} alt="pfp"/>
                             <input
                                 type="file"
                                 ref={fileInputRef}
@@ -166,38 +198,66 @@ export const Profile = () => {
                                 <div className="space-y-2">
                                     <label htmlFor="firstName">First Name</label>
                                     <input name="firstName" type="text" defaultValue={member.name?.split(" ")[0]}
-                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                           disabled={!isEditable}
+                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="lastName">Last Name</label>
                                     <input name="lastName" type="text" defaultValue={member.name?.split(" ")[1]}
-                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                           disabled={!isEditable}
+                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="age">Age</label>
-                                    <input name="age" type="text" defaultValue={healthInfo.age}
-                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                    <input name="age" type="text" value={healthInfo.age} disabled={true} readOnly
+                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                    <input ref={dobInputRef} type="date" name="dateOfBirth"
+                                           defaultValue={member.dateOfBirth}
+                                           max={new Date().toISOString().slice(0, 10)} min="1900-01-01"
+                                           onChange={(e) => setPendingDob(e.currentTarget.value)}
+                                           className="absolute opacity-0 pointer-events-none w-0 h-0"/>
+                                    <button type="button"
+                                            onClick={() => dobInputRef.current?.showPicker()}
+                                            className="bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-1 p-2 rounded-md cursor-pointer">
+                                        Edit Date of Birth
+                                    </button>
+                                    {pendingDob && pendingDob !== member.dateOfBirth && (
+                                        <div className="mt-2 flex gap-2 items-center">
+                                            <span className="text-sm">New: {pendingDob}</span>
+                                            <button type="button" onClick={() => saveDob(pendingDob)}
+                                                    className="bg-[#3f76c0] hover:bg-[#355a8f] duration-300 p-1 px-2 rounded-md cursor-pointer text-sm">
+                                                Save
+                                            </button>
+                                            <button type="button" onClick={() => setPendingDob(null)}
+                                                    className="bg-gray-500 hover:bg-gray-600 duration-300 p-1 px-2 rounded-md cursor-pointer text-sm">
+                                                Cancel
+                                            </button>
+                                        </div>
+                                    )}
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="weight">Weight (lbs)</label>
                                     <input name="weight" type="text" defaultValue={healthInfo.weight}
-                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                           disabled={!isEditable}
+                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="height">Height (inches)</label>
                                     <input name="height" type="number" defaultValue={healthInfo.height}
-                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                           disabled={!isEditable}
+                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="bodyFat">Body Fat%</label>
                                     <input name="bodyFat" type="number" defaultValue={healthInfo.bodyFat}
-                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                           disabled={!isEditable}
+                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="gender">Gender</label>
                                     {member && (
-                                        <select name="gender" defaultValue={healthInfo.gender}
-                                            className="border-2 border-gray-600 rounded-md p-2 w-full">
+                                        <select name="gender" defaultValue={healthInfo.gender} disabled={!isEditable}
+                                                className="border-2 border-gray-600 rounded-md p-2 w-full">
                                             <option value="">
                                                 Select Gender
                                             </option>
@@ -211,7 +271,8 @@ export const Profile = () => {
                                     <label htmlFor="activity">Fitness Experience</label>
                                     {member && (
                                         <select name="activity" defaultValue={healthInfo.activity}
-                                            className="border-2 border-gray-600 rounded-md p-2 w-full">
+                                                disabled={!isEditable}
+                                                className="border-2 border-gray-600 rounded-md p-2 w-full">
                                             <option value="">
                                                 Select Activity Experience
                                             </option>
@@ -227,13 +288,22 @@ export const Profile = () => {
                                 <div className="space-y-2">
                                     <label htmlFor="email">Email</label>
                                     <input name="email" type="text" defaultValue={member.email}
-                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                           disabled={!isEditable}
+                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                             </div>
-                            <button
-                                className="w-full h-12 bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-2 rounded-md cursor-pointer">Save
-                                Changes
-                            </button>
+                            <div className="flex flex-col md:flex-row gap-4 justify-between items-center">
+                                <button
+                                    className="w-full h-12 bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-2 rounded-md cursor-pointer">
+                                    {isEditable ? "Save Changes" : "Edit Health Information"}
+                                </button>
+                                {isEditable && (
+                                    <button className="w-full h-12 bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-2 rounded-md cursor-pointer"
+                                    onClick={() => setIsEditable(false)}>
+                                        Cancel
+                                    </button>
+                                )}
+                            </div>
                         </form>
                     </div>
                 </div>

--- a/fit-track-ui/react/src/pages/profile/Profile.tsx
+++ b/fit-track-ui/react/src/pages/profile/Profile.tsx
@@ -6,6 +6,7 @@ import {buildProfileImage} from "../../services/client.ts";
 import {toast} from "sonner";
 import {authenticatedMember} from "../layout.tsx";
 import {useAuth} from "../../context/AuthContext.tsx";
+import {calculateAge} from "../../utils/utilities.ts";
 
 
 export const Profile = () => {
@@ -36,16 +37,7 @@ export const Profile = () => {
         return <div>Loading...</div>;
     }
 
-    const calculateAge = (dateOfBirth: string) => {
-        const today = new Date();
-        const birthDate = new Date(dateOfBirth);
-        let age = today.getFullYear() - birthDate.getFullYear();
-        const monthDifference = today.getMonth() - birthDate.getMonth();
-        if (monthDifference < 0 || (monthDifference === 0 && today.getDate() < birthDate.getDate())) {
-            age--;
-        }
-        return age;
-    }
+
     const profile = {
         name: member.name,
         email: member.email,
@@ -111,7 +103,7 @@ export const Profile = () => {
             console.error("Failed to update member.", error);
             toast.error("Failed to update date of birth.");
         }
-    }
+    };
 
     const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -158,7 +150,7 @@ export const Profile = () => {
                     <div className="flex flex-col items-center">
                         <div className="w-24 h-24 mb-4 relative">
                             <img className="rounded-[50%] object-cover w-20 h-20 z-1"
-                                 src={pfp} alt="pfp"/>
+                                src={pfp} alt="pfp"/>
                             <input
                                 type="file"
                                 ref={fileInputRef}
@@ -198,38 +190,38 @@ export const Profile = () => {
                                 <div className="space-y-2">
                                     <label htmlFor="firstName">First Name</label>
                                     <input name="firstName" type="text" defaultValue={member.name?.split(" ")[0]}
-                                           disabled={!isEditable}
-                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                        disabled={!isEditable}
+                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="lastName">Last Name</label>
                                     <input name="lastName" type="text" defaultValue={member.name?.split(" ")[1]}
-                                           disabled={!isEditable}
-                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                        disabled={!isEditable}
+                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="age">Age</label>
                                     <input name="age" type="text" value={healthInfo.age} disabled={true} readOnly
-                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                     <input ref={dobInputRef} type="date" name="dateOfBirth"
-                                           defaultValue={member.dateOfBirth}
-                                           max={new Date().toISOString().slice(0, 10)} min="1900-01-01"
-                                           onChange={(e) => setPendingDob(e.currentTarget.value)}
-                                           className="absolute opacity-0 pointer-events-none w-0 h-0"/>
+                                        defaultValue={member.dateOfBirth}
+                                        max={new Date().toISOString().slice(0, 10)} min="1900-01-01"
+                                        onChange={(e) => setPendingDob(e.currentTarget.value)}
+                                        className="absolute opacity-0 pointer-events-none w-0 h-0"/>
                                     <button type="button"
-                                            onClick={() => dobInputRef.current?.showPicker()}
-                                            className="bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-1 p-2 rounded-md cursor-pointer">
+                                        onClick={() => dobInputRef.current?.showPicker()}
+                                        className="bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-1 p-2 rounded-md cursor-pointer">
                                         Edit Date of Birth
                                     </button>
                                     {pendingDob && pendingDob !== member.dateOfBirth && (
                                         <div className="mt-2 flex gap-2 items-center">
                                             <span className="text-sm">New: {pendingDob}</span>
                                             <button type="button" onClick={() => saveDob(pendingDob)}
-                                                    className="bg-[#3f76c0] hover:bg-[#355a8f] duration-300 p-1 px-2 rounded-md cursor-pointer text-sm">
+                                                className="bg-[#3f76c0] hover:bg-[#355a8f] duration-300 p-1 px-2 rounded-md cursor-pointer text-sm">
                                                 Save
                                             </button>
                                             <button type="button" onClick={() => setPendingDob(null)}
-                                                    className="bg-gray-500 hover:bg-gray-600 duration-300 p-1 px-2 rounded-md cursor-pointer text-sm">
+                                                className="bg-gray-500 hover:bg-gray-600 duration-300 p-1 px-2 rounded-md cursor-pointer text-sm">
                                                 Cancel
                                             </button>
                                         </div>
@@ -238,26 +230,26 @@ export const Profile = () => {
                                 <div className="space-y-2">
                                     <label htmlFor="weight">Weight (lbs)</label>
                                     <input name="weight" type="text" defaultValue={healthInfo.weight}
-                                           disabled={!isEditable}
-                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                        disabled={!isEditable}
+                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="height">Height (inches)</label>
                                     <input name="height" type="number" defaultValue={healthInfo.height}
-                                           disabled={!isEditable}
-                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                        disabled={!isEditable}
+                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="bodyFat">Body Fat%</label>
                                     <input name="bodyFat" type="number" defaultValue={healthInfo.bodyFat}
-                                           disabled={!isEditable}
-                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                        disabled={!isEditable}
+                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                                 <div className="space-y-2">
                                     <label htmlFor="gender">Gender</label>
                                     {member && (
                                         <select name="gender" defaultValue={healthInfo.gender} disabled={!isEditable}
-                                                className="border-2 border-gray-600 rounded-md p-2 w-full">
+                                            className="border-2 border-gray-600 rounded-md p-2 w-full">
                                             <option value="">
                                                 Select Gender
                                             </option>
@@ -271,8 +263,8 @@ export const Profile = () => {
                                     <label htmlFor="activity">Fitness Experience</label>
                                     {member && (
                                         <select name="activity" defaultValue={healthInfo.activity}
-                                                disabled={!isEditable}
-                                                className="border-2 border-gray-600 rounded-md p-2 w-full">
+                                            disabled={!isEditable}
+                                            className="border-2 border-gray-600 rounded-md p-2 w-full">
                                             <option value="">
                                                 Select Activity Experience
                                             </option>
@@ -288,8 +280,8 @@ export const Profile = () => {
                                 <div className="space-y-2">
                                     <label htmlFor="email">Email</label>
                                     <input name="email" type="text" defaultValue={member.email}
-                                           disabled={!isEditable}
-                                           className="border-2 border-gray-600 rounded-md p-2 w-full"/>
+                                        disabled={!isEditable}
+                                        className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                 </div>
                             </div>
                             <div className="flex flex-col md:flex-row gap-4 justify-between items-center">
@@ -299,7 +291,7 @@ export const Profile = () => {
                                 </button>
                                 {isEditable && (
                                     <button className="w-full h-12 bg-[#3f76c0] hover:bg-[#355a8f] duration-300 mt-2 rounded-md cursor-pointer"
-                                    onClick={() => setIsEditable(false)}>
+                                        onClick={() => setIsEditable(false)}>
                                         Cancel
                                     </button>
                                 )}

--- a/fit-track-ui/react/src/pages/profile/Profile.tsx
+++ b/fit-track-ui/react/src/pages/profile/Profile.tsx
@@ -204,7 +204,7 @@ export const Profile = () => {
                                     <input name="age" type="text" value={healthInfo.age} disabled={true} readOnly
                                         className="border-2 border-gray-600 rounded-md p-2 w-full"/>
                                     <input ref={dobInputRef} type="date" name="dateOfBirth"
-                                        defaultValue={member.dateOfBirth}
+                                        defaultValue={member.dateOfBirth || ""}
                                         max={new Date().toISOString().slice(0, 10)} min="1900-01-01"
                                         onChange={(e) => setPendingDob(e.currentTarget.value)}
                                         className="absolute opacity-0 pointer-events-none w-0 h-0"/>

--- a/fit-track-ui/react/src/utils/utilities.test.ts
+++ b/fit-track-ui/react/src/utils/utilities.test.ts
@@ -1,0 +1,156 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+import {WorkoutDTO} from "../api/generated/models";
+import {
+    calculateAge,
+    getWeekOf,
+    isDateInSelectedWeek,
+    isDateInThisWeek,
+    sortWorkouts,
+    sortWorkoutsAsc,
+} from "./utilities";
+
+describe("calculateAge", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-05-05T12:00:00"));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it("returns 0 when dateOfBirth is empty", () => {
+        expect(calculateAge("")).toBe(0);
+    });
+
+    it("calculates age when birthday already passed this year", () => {
+        expect(calculateAge("1990-01-15")).toBe(36);
+    });
+
+    it("subtracts a year when birthday hasn't happened yet this year", () => {
+        expect(calculateAge("1990-12-25")).toBe(35);
+    });
+
+    it("does not decrement when birthday is today", () => {
+        expect(calculateAge("1990-05-05")).toBe(36);
+    });
+
+    it("decrements when birthday is tomorrow", () => {
+        expect(calculateAge("1990-05-06")).toBe(35);
+    });
+
+    it("handles a leap-day birthday in a non-leap year", () => {
+        // 2026 is not a leap year; today (May 5) is past Feb 28, so birthday counts as passed
+        expect(calculateAge("2000-02-29")).toBe(26);
+    });
+});
+
+describe("isDateInThisWeek", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        // 2026-05-05 is a Tuesday → week (Sun–Sat) is 2026-05-03 .. 2026-05-09
+        vi.setSystemTime(new Date("2026-05-05T12:00:00"));
+    });
+    afterEach(() => vi.useRealTimers());
+
+    it("returns true for today", () => {
+        expect(isDateInThisWeek(new Date(2026, 4, 5))).toBe(true);
+    });
+
+    it("returns true for the first day of the week (Sunday)", () => {
+        expect(isDateInThisWeek(new Date(2026, 4, 3))).toBe(true);
+    });
+
+    it("returns true for the last day of the week (Saturday)", () => {
+        expect(isDateInThisWeek(new Date(2026, 4, 9))).toBe(true);
+    });
+
+    it("returns false for the previous Saturday", () => {
+        expect(isDateInThisWeek(new Date(2026, 4, 2))).toBe(false);
+    });
+
+    it("returns false for the next Sunday", () => {
+        expect(isDateInThisWeek(new Date(2026, 4, 10))).toBe(false);
+    });
+});
+
+describe("getWeekOf", () => {
+    it("pushes first and last day strings into the array in order", () => {
+        const result: string[] = [];
+        const start = new Date("2026-05-03T00:00:00");
+
+        getWeekOf(start, result);
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toBe(start.toDateString());
+
+        const expectedLast = new Date(start);
+        expectedLast.setDate(expectedLast.getDate() + 6);
+        expect(result[1]).toBe(expectedLast.toDateString());
+    });
+
+    it("returns the new array length from push()", () => {
+        const result: string[] = ["existing"];
+        const ret = getWeekOf(new Date("2026-05-03T00:00:00"), result);
+        expect(ret).toBe(3);
+    });
+});
+
+describe("isDateInSelectedWeek", () => {
+    it("returns true when date equals the start of the selected week", () => {
+        const selectedWeek = new Date("2026-05-03T00:00:00");
+        expect(isDateInSelectedWeek(new Date("2026-05-03T00:00:00"), selectedWeek)).toBe(true);
+    });
+
+    it("returns true when date is the last day of the week (start + 6)", () => {
+        const selectedWeek = new Date("2026-05-03T00:00:00");
+        expect(isDateInSelectedWeek(new Date("2026-05-09T00:00:00"), selectedWeek)).toBe(true);
+    });
+
+    it("returns false for the day before the selected week", () => {
+        const selectedWeek = new Date("2026-05-03T00:00:00");
+        expect(isDateInSelectedWeek(new Date("2026-05-02T00:00:00"), selectedWeek)).toBe(false);
+    });
+
+    it("returns false for the day after the selected week", () => {
+        const selectedWeek = new Date("2026-05-03T00:00:00");
+        expect(isDateInSelectedWeek(new Date("2026-05-10T00:00:00"), selectedWeek)).toBe(false);
+    });
+});
+
+const makeWorkout = (id: number, workoutDate: string): WorkoutDTO => ({
+    id,
+    memberId: 1,
+    title: "test",
+    workoutType: "Cardio",
+    exercises: [],
+    volume: 0,
+    calories: 0,
+    durationMinutes: 0,
+    workoutDate,
+});
+
+describe("sortWorkouts", () => {
+    it("sorts workouts by workoutDate descending", () => {
+        const workouts = [
+            makeWorkout(1, "2026-01-01"),
+            makeWorkout(2, "2026-05-01"),
+            makeWorkout(3, "2026-03-01"),
+        ];
+
+        const sorted = sortWorkouts(workouts);
+
+        expect(sorted.map(w => w.id)).toEqual([2, 3, 1]);
+    });
+});
+
+describe("sortWorkoutsAsc", () => {
+    it("sorts workouts by workoutDate ascending", () => {
+        const workouts = [
+            makeWorkout(1, "2026-05-01"),
+            makeWorkout(2, "2026-01-01"),
+            makeWorkout(3, "2026-03-01"),
+        ];
+
+        const sorted = sortWorkoutsAsc(workouts);
+
+        expect(sorted.map(w => w.id)).toEqual([2, 3, 1]);
+    });
+});

--- a/fit-track-ui/react/src/utils/utilities.ts
+++ b/fit-track-ui/react/src/utils/utilities.ts
@@ -53,3 +53,16 @@ export function sortWorkoutsAsc(workouts: WorkoutDTO[]): WorkoutDTO[] {
         return new Date(a.workoutDate).getTime() - new Date(b.workoutDate).getTime();
     });
 }
+
+export function calculateAge(dateOfBirth: string){
+    if (!dateOfBirth) return 0;
+    const [year, month, day] = dateOfBirth.split("-").map(Number);
+    const birthDate = new Date(year, month - 1, day);
+    const today = new Date();
+    let age = today.getFullYear() - birthDate.getFullYear();
+    const monthDifference = today.getMonth() - birthDate.getMonth();
+    if (monthDifference < 0 || (monthDifference === 0 && today.getDate() < birthDate.getDate())) {
+        age--;
+    }
+    return age;
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/api/MemberController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/api/MemberController.java
@@ -53,7 +53,7 @@ public class MemberController {
     @GetMapping("{memberId}")
     public MemberDTO getMember(
             @Parameter(description = "memberId", required = true) @PathVariable final Long memberId) {
-        return memberService.getMember(memberId);
+        return memberService.getMemberById(memberId);
     }
 
     @ApiResponse(responseCode = "409", description = "Member already exists")

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/member/MemberEntity.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/member/MemberEntity.java
@@ -12,8 +12,10 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 
 @Data
@@ -31,8 +33,8 @@ public class MemberEntity extends AbstractModifiedDateEntity implements UserDeta
     @Column(name = "email", nullable = false)
     private String email;
 
-    @Column(name = "age", nullable = false)
-    private Integer age;
+    @Column(name = "date_of_birth", nullable = false)
+    private LocalDate dateOfBirth;
 
     @Column(name = "gender", nullable = false)
     @Enumerated(EnumType.STRING)

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/member/MemberDTO.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/member/MemberDTO.java
@@ -3,6 +3,7 @@ package com.robinsonir.fittrack.data.repository.member;
 import com.robinsonir.fittrack.data.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -17,7 +18,7 @@ public record MemberDTO(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Gender gender,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Integer age,
+        LocalDate dateOfBirth,
         Integer weight,
         Integer height,
         Integer weightGoal,

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/member/MemberRepository.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/member/MemberRepository.java
@@ -2,18 +2,13 @@ package com.robinsonir.fittrack.data.repository.member;
 
 import com.robinsonir.fittrack.data.entity.member.MemberEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long>, MemberUpdateRepository {
 
-    @Query("select m from MemberEntity m where m.email = ?1")
-    Optional<MemberEntity> findMemberByEmail(String email);
-
-    @Query("select m from MemberEntity m where m.email = ?1")
-    Optional<MemberEntity> findMemberByUsername(String username);
+    Optional<MemberEntity> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/member/MemberUpdateRepository.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/member/MemberUpdateRepository.java
@@ -2,7 +2,6 @@ package com.robinsonir.fittrack.data.repository.member;
 
 public interface MemberUpdateRepository {
 
-
     void updateProfileImageId(String profileImageId, Long customerId);
 
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberRegistrationRequest.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberRegistrationRequest.java
@@ -3,6 +3,8 @@ package com.robinsonir.fittrack.data.service.member;
 import com.robinsonir.fittrack.data.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDate;
+
 @Schema(name = "MemberRegistrationRequest")
 public record MemberRegistrationRequest(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
@@ -12,7 +14,7 @@ public record MemberRegistrationRequest(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String password,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Integer age,
+        LocalDate dateOfBirth,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Gender gender
 ) {

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberRegistrationRequest.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberRegistrationRequest.java
@@ -2,6 +2,7 @@ package com.robinsonir.fittrack.data.service.member;
 
 import com.robinsonir.fittrack.data.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.PastOrPresent;
 
 import java.time.LocalDate;
 
@@ -13,6 +14,7 @@ public record MemberRegistrationRequest(
         String email,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String password,
+        @PastOrPresent(message = "Date of birth must be in the past")
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDate dateOfBirth,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberService.java
@@ -53,7 +53,7 @@ public class MemberService {
     }
 
 
-    public MemberDTO getMember(Long id) {
+    public MemberDTO getMemberById(Long id) {
         MemberEntity memberEntity = memberRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "member with id [%s] not found".formatted(id)
@@ -141,8 +141,8 @@ public class MemberService {
 
         if (updateRequest.name() != null)
             memberEntity.setName(updateRequest.name());
-        if (updateRequest.age() != null)
-            memberEntity.setAge(updateRequest.age());
+        if (updateRequest.dateOfBirth() != null)
+            memberEntity.setDateOfBirth(updateRequest.dateOfBirth());
         if (updateRequest.gender() != null)
             memberEntity.setGender(updateRequest.gender());
         if (updateRequest.weight() != null)

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberUpdateRequest.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberUpdateRequest.java
@@ -1,12 +1,14 @@
 package com.robinsonir.fittrack.data.service.member;
 
 import com.robinsonir.fittrack.data.Gender;
+import jakarta.validation.constraints.PastOrPresent;
 
 import java.time.LocalDate;
 
 public record MemberUpdateRequest(
       String name,
       String email,
+      @PastOrPresent(message = "Date of birth must be in the past")
       LocalDate dateOfBirth,
       Gender gender,
       Integer weight,

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberUpdateRequest.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberUpdateRequest.java
@@ -2,10 +2,12 @@ package com.robinsonir.fittrack.data.service.member;
 
 import com.robinsonir.fittrack.data.Gender;
 
+import java.time.LocalDate;
+
 public record MemberUpdateRequest(
       String name,
       String email,
-      Integer age,
+      LocalDate dateOfBirth,
       Gender gender,
       Integer weight,
       Integer height,

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberUserDetailService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberUserDetailService.java
@@ -17,7 +17,7 @@ public class MemberUserDetailService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberRepository.findMemberByUsername(username)
+        return memberRepository.findByEmail(username)
                 .orElseThrow(() -> new UsernameNotFoundException(
                         "Username " + username + " not found"));
     }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/mappers/MemberMapper.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/mappers/MemberMapper.java
@@ -25,7 +25,7 @@ public interface MemberMapper {
     @Mapping(target = "name", source = "name")
     @Mapping(target = "email", source = "email")
     @Mapping(target = "password", source = "password")
-    @Mapping(target = "age", source = "age")
+    @Mapping(target = "dateOfBirth", source = "dateOfBirth")
     @Mapping(target = "gender", source = "gender")
     @Mapping(target = "memberSince", ignore = true)
     MemberEntity registrationRequestToEntity(MemberRegistrationRequest registrationRequest);

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/SecurityFilterChainConfig.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/SecurityFilterChainConfig.java
@@ -53,7 +53,8 @@ public class SecurityFilterChainConfig {
                         "/api/v1/members"
                 )
                 .permitAll()
-                .requestMatchers("/swagger-ui/**",
+                .requestMatchers(
+                        "/swagger-ui/**",
                         "/actuator/**",
                         "/swagger-ui.html",
                         "/v3/api-docs/**",

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtil.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtil.java
@@ -38,7 +38,7 @@ public class JwtTokenUtil {
                 .subject(subject)
                 .issuer("fittrack")
                 .issuedAt(Date.from(Instant.now()))
-                .expiration(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
+                .expiration(Date.from(Instant.now().plus(15, ChronoUnit.MINUTES)))
                 .signWith(getSigningKey())
                 .compact();
     }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtil.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtil.java
@@ -38,7 +38,7 @@ public class JwtTokenUtil {
                 .subject(subject)
                 .issuer("fittrack")
                 .issuedAt(Date.from(Instant.now()))
-                .expiration(Date.from(Instant.now().plus(15, ChronoUnit.MINUTES)))
+                .expiration(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
                 .signWith(getSigningKey())
                 .compact();
     }

--- a/fit-track/src/main/resources/db/migration/V202605031632__fit-track_alter_age_to_date_of_birth.sql
+++ b/fit-track/src/main/resources/db/migration/V202605031632__fit-track_alter_age_to_date_of_birth.sql
@@ -3,8 +3,8 @@ ALTER TABLE fit_tracker.member
     ADD COLUMN date_of_birth DATE NOT NULL DEFAULT '1900-01-01';
 
 
-ALTER  TABLE fit_tracker.member_aud
+ALTER TABLE fit_tracker.member_aud
     DROP COLUMN age,
     DROP COLUMN age_mod,
-    ADD COLUMN date_of_birth DATE,
+    ADD COLUMN date_of_birth DATE NOT NULL DEFAULT '1900-01-01',
     ADD COLUMN date_of_birth_mod BOOLEAN;

--- a/fit-track/src/main/resources/db/migration/V202605031632__fit-track_alter_age_to_date_of_birth.sql
+++ b/fit-track/src/main/resources/db/migration/V202605031632__fit-track_alter_age_to_date_of_birth.sql
@@ -1,0 +1,10 @@
+ALTER TABLE fit_tracker.member
+    DROP COLUMN age,
+    ADD COLUMN date_of_birth DATE NOT NULL DEFAULT '1900-01-01';
+
+
+ALTER  TABLE fit_tracker.member_aud
+    DROP COLUMN age,
+    DROP COLUMN age_mod,
+    ADD COLUMN date_of_birth DATE,
+    ADD COLUMN date_of_birth_mod BOOLEAN;

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/repository/member/MemberRepositoryTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/repository/member/MemberRepositoryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -23,7 +24,7 @@ public class MemberRepositoryTest {
         member.setName("John Doe");
         member.setEmail("john.doe@example.com");
         member.setPassword("password123");
-        member.setAge(30);
+        member.setDateOfBirth(LocalDate.of(1995, 1, 1));
         member.setGender(Gender.MALE);
 
         MemberEntity savedMember = memberRepository.save(member);
@@ -40,7 +41,7 @@ public class MemberRepositoryTest {
         member.setName("Jane Doe");
         member.setEmail("jane.doe@example.com");
         member.setPassword("securePass");
-        member.setAge(28);
+        member.setDateOfBirth(LocalDate.of(1997, 6, 15));
         member.setGender(Gender.FEMALE);
 
         memberRepository.save(member);
@@ -52,17 +53,17 @@ public class MemberRepositoryTest {
     }
 
     @Test
-    void testFindMemberByEmail() {
+    void testFindByEmail() {
         MemberEntity member = new MemberEntity();
         member.setName("Jane Doe");
         member.setEmail("jane.doe@example.com");
         member.setPassword("securePass");
-        member.setAge(28);
+        member.setDateOfBirth(LocalDate.of(1997, 6, 15));
         member.setGender(Gender.FEMALE);
 
         memberRepository.save(member);
 
-        Optional<MemberEntity> foundMember = memberRepository.findMemberByEmail(member.getEmail());
+        Optional<MemberEntity> foundMember = memberRepository.findByEmail(member.getEmail());
 
         assertTrue(foundMember.isPresent());
         assertEquals("jane.doe@example.com", foundMember.get().getEmail());
@@ -74,7 +75,7 @@ public class MemberRepositoryTest {
         member.setName("Alice Johnson");
         member.setEmail("alice.johnson@example.com");
         member.setPassword("alicePass");
-        member.setAge(29);
+        member.setDateOfBirth(LocalDate.of(1996, 3, 10));
         member.setGender(Gender.FEMALE);
 
         memberRepository.save(member);
@@ -92,7 +93,7 @@ public class MemberRepositoryTest {
         member.setName("Daniel Craig");
         member.setEmail("daniel.craig@example.com");
         member.setPassword("bond007");
-        member.setAge(50);
+        member.setDateOfBirth(LocalDate.of(1975, 4, 12));
         member.setGender(Gender.MALE);
 
         memberRepository.save(member);

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/repository/workout/WorkoutRepositoryTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/repository/workout/WorkoutRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
 import java.util.List;
@@ -33,7 +34,7 @@ public class WorkoutRepositoryTest {
         member.setName("John Doe");
         member.setEmail("john.doe@example.com");
         member.setPassword("password123");
-        member.setAge(30);
+        member.setDateOfBirth(LocalDate.of(1995, 1, 1));
         member.setGender(Gender.MALE);
 
         memberRepository.save(member);
@@ -64,7 +65,7 @@ public class WorkoutRepositoryTest {
         member.setName("Jane Doe");
         member.setEmail("jane.doe@example.com");
         member.setPassword("securePass");
-        member.setAge(28);
+        member.setDateOfBirth(LocalDate.of(1997, 6, 15));
         member.setGender(Gender.FEMALE);
 
         memberRepository.save(member);
@@ -94,7 +95,7 @@ public class WorkoutRepositoryTest {
         member1.setName("Bob Smith");
         member1.setEmail("bob.smith@example.com");
         member1.setPassword("bobPass");
-        member1.setAge(35);
+        member1.setDateOfBirth(LocalDate.of(1990, 4, 20));
         member1.setGender(Gender.MALE);
 
         memberRepository.save(member1);
@@ -103,7 +104,7 @@ public class WorkoutRepositoryTest {
         member2.setName("Alice Johnson");
         member2.setEmail("alice.johnson@example.com");
         member2.setPassword("alicePass");
-        member2.setAge(29);
+        member2.setDateOfBirth(LocalDate.of(1996, 3, 10));
         member2.setGender(Gender.FEMALE);
         memberRepository.save(member2);
 
@@ -141,7 +142,7 @@ public class WorkoutRepositoryTest {
         member.setName("Chris Evans");
         member.setEmail("chris.evans@example.com");
         member.setPassword("captain123");
-        member.setAge(40);
+        member.setDateOfBirth(LocalDate.of(1985, 7, 1));
         member.setGender(Gender.MALE);
         memberRepository.save(member);
 
@@ -164,7 +165,7 @@ public class WorkoutRepositoryTest {
         newMember.setName("Mark Ruffalo");
         newMember.setEmail("mark.ruffalo@example.com");
         newMember.setPassword("hulk123");
-        newMember.setAge(53);
+        newMember.setDateOfBirth(LocalDate.of(1972, 11, 22));
         newMember.setGender(Gender.MALE);
         memberRepository.save(newMember);
 
@@ -179,7 +180,7 @@ public class WorkoutRepositoryTest {
         member.setName("John Doe");
         member.setEmail("johndoe@example.com");
         member.setPassword("password");
-        member.setAge(30);
+        member.setDateOfBirth(LocalDate.of(1995, 1, 1));
         member.setGender(Gender.MALE);
 
         // Create some workouts for the member

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/service/member/MemberServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/service/member/MemberServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,38 +60,39 @@ public class MemberServiceTest {
     }
 
     @Test
-    void testGetMember() {
+    void testGetMemberById() {
         // Arrange
         Long memberId = 1L;
+        LocalDate dateOfBirth = LocalDate.of(1995, 1, 1);
         MemberEntity memberEntity = new MemberEntity();
         memberEntity.setId(memberId);
         memberEntity.setName("John Doe");
         memberEntity.setEmail("john.doe@example.com");
         memberEntity.setPassword("password123");
-        memberEntity.setAge(30);
+        memberEntity.setDateOfBirth(dateOfBirth);
         memberEntity.setGender(Gender.MALE);
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberEntity));
 
         // Act
-        MemberDTO member = memberTest.getMember(memberId);
+        MemberDTO member = memberTest.getMemberById(memberId);
 
         // Assert
         assertEquals(memberId, member.id());
         assertEquals("John Doe", member.name());
         assertEquals("john.doe@example.com", member.email());
-        assertEquals(30, member.age());
+        assertEquals(dateOfBirth, member.dateOfBirth());
         assertEquals(Gender.MALE, member.gender());
     }
 
     @Test
-    void testGetMemberNotFound() {
+    void testGetMemberByIdNotFound() {
         // Arrange
         Long memberId = 99L;
         when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
 
         // Act & Assert
-        assertThatThrownBy(() -> memberTest.getMember(memberId))
+        assertThatThrownBy(() -> memberTest.getMemberById(memberId))
                 .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("member with id [99] not found");
     }
@@ -98,11 +100,12 @@ public class MemberServiceTest {
     @Test
     void addMember() {
         // Arrange
+        LocalDate dateOfBirth = LocalDate.of(1995, 1, 1);
         MemberRegistrationRequest registrationRequest = new MemberRegistrationRequest(
                 "John Doe",
                 "johndoe@example.com",
                 "password123",
-                30,
+                dateOfBirth,
                 Gender.MALE
         );
 
@@ -118,7 +121,7 @@ public class MemberServiceTest {
                         member.getName().equals(registrationRequest.name()) &&
                                 member.getEmail().equals(registrationRequest.email()) &&
                                 member.getPassword().equals("hashedPassword") &&
-                                member.getAge().equals(registrationRequest.age()) &&
+                                member.getDateOfBirth().equals(registrationRequest.dateOfBirth()) &&
                                 member.getGender().equals(registrationRequest.gender())
                 )
         );
@@ -126,7 +129,7 @@ public class MemberServiceTest {
         // Assert — returned DTO reflects the registered member
         assertThat(result.name()).isEqualTo("John Doe");
         assertThat(result.email()).isEqualTo("johndoe@example.com");
-        assertThat(result.age()).isEqualTo(30);
+        assertThat(result.dateOfBirth()).isEqualTo(dateOfBirth);
         assertThat(result.gender()).isEqualTo(Gender.MALE);
     }
 
@@ -137,7 +140,7 @@ public class MemberServiceTest {
                 "John Doe",
                 "johndoe@example.com",
                 "password123",
-                30,
+                LocalDate.of(1995, 1, 1),
                 Gender.MALE
         );
         when(memberRepository.existsByEmail(registrationRequest.email())).thenReturn(true);
@@ -159,13 +162,14 @@ public class MemberServiceTest {
         existingMember.setName("John Doe");
         existingMember.setEmail("john.doe@example.com");
         existingMember.setPassword("hashedPassword");
-        existingMember.setAge(30);
+        existingMember.setDateOfBirth(LocalDate.of(1995, 1, 1));
         existingMember.setGender(Gender.MALE);
 
+        LocalDate updatedDob = LocalDate.of(1997, 6, 15);
         MemberUpdateRequest updateRequest = new MemberUpdateRequest(
                 "Jane Doe",
                 "jane@example.com",
-                28,
+                updatedDob,
                 Gender.FEMALE,
                 65,
                 170,
@@ -183,7 +187,7 @@ public class MemberServiceTest {
         // Assert — returned DTO reflects the updates
         assertThat(result.name()).isEqualTo("Jane Doe");
         assertThat(result.email()).isEqualTo("jane@example.com");
-        assertThat(result.age()).isEqualTo(28);
+        assertThat(result.dateOfBirth()).isEqualTo(updatedDob);
         assertThat(result.gender()).isEqualTo(Gender.FEMALE);
         assertThat(result.weight()).isEqualTo(65);
         assertThat(result.height()).isEqualTo(170);
@@ -200,11 +204,12 @@ public class MemberServiceTest {
     void testUpdateMemberPartialOnlyUpdatesNonNullFields() {
         // Arrange
         Long memberId = 1L;
+        LocalDate originalDob = LocalDate.of(1995, 1, 1);
         MemberEntity existingMember = new MemberEntity();
         existingMember.setId(memberId);
         existingMember.setName("John Doe");
         existingMember.setEmail("john.doe@example.com");
-        existingMember.setAge(30);
+        existingMember.setDateOfBirth(originalDob);
         existingMember.setGender(Gender.MALE);
         existingMember.setWeight(80);
         existingMember.setActivity("Running");
@@ -212,7 +217,7 @@ public class MemberServiceTest {
         MemberUpdateRequest partialRequest = new MemberUpdateRequest(
                 null,      // name — unchanged
                 null,      // email — unchanged
-                null,      // age — unchanged
+                null,      // dateOfBirth — unchanged
                 null,      // gender — unchanged
                 75,        // weight — updated
                 null,      // height — unchanged
@@ -229,7 +234,7 @@ public class MemberServiceTest {
         // Assert — only weight and weightGoal changed; rest preserved
         assertThat(result.name()).isEqualTo("John Doe");
         assertThat(result.email()).isEqualTo("john.doe@example.com");
-        assertThat(result.age()).isEqualTo(30);
+        assertThat(result.dateOfBirth()).isEqualTo(originalDob);
         assertThat(result.gender()).isEqualTo(Gender.MALE);
         assertThat(result.weight()).isEqualTo(75);
         assertThat(result.weightGoal()).isEqualTo(70);
@@ -333,7 +338,7 @@ public class MemberServiceTest {
         testMemberEntity.setName("John Doe");
         testMemberEntity.setEmail("john.doe@example.com");
         testMemberEntity.setPassword("hashedPassword");
-        testMemberEntity.setAge(30);
+        testMemberEntity.setDateOfBirth(LocalDate.of(1995, 1, 1));
         testMemberEntity.setGender(Gender.MALE);
         testMemberEntity.setProfileImageId(profileImageId);
 
@@ -369,7 +374,7 @@ public class MemberServiceTest {
         testMemberEntity.setName("John Doe");
         testMemberEntity.setEmail("john.doe@example.com");
         testMemberEntity.setPassword("hashedPassword");
-        testMemberEntity.setAge(30);
+        testMemberEntity.setDateOfBirth(LocalDate.of(1995, 1, 1));
         testMemberEntity.setGender(Gender.MALE);
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(testMemberEntity));

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -52,7 +53,7 @@ public class WorkoutServiceTest {
         member.setName("John Doe");
         member.setEmail("john.doe@example.com");
         member.setPassword("password");
-        member.setAge(30);
+        member.setDateOfBirth(LocalDate.of(1995, 1, 1));
         member.setGender(Gender.MALE);
     }
 


### PR DESCRIPTION
# FTRACK-2: Replace Member Age Field with Date of Birth

## Description

- Replaces the integer `age` column on `member` with a `date_of_birth` DATE column across the full stack (DB, backend, frontend, Bruno, tests).
- Age is no longer stored — it's computed client-side from `dateOfBirth` so it never goes stale.
- Adds an "Edit Date of Birth" flow on the Profile page using the native `<input type="date">` picker with explicit Save/Cancel confirmation, and exposes `refreshMember()` from `AuthContext` so the displayed age refreshes without a full page reload.

## Changes

- **DB migration** `V202605031632__fit-track_alter_age_to_date_of_birth.sql`: drops `age`, adds `date_of_birth DATE`.
- **Backend** (`MemberEntity`, `MemberDTO`, `MemberRegistrationRequest`, `MemberUpdateRequest`, `MemberService`, `MemberMapper`, `MemberRepository`, etc.): `int age` → `LocalDate dateOfBirth`.
- **Frontend signup** (`SignUp.tsx`): replaces age input with a date input bounded by `min="1900-01-01"` and a `todayISO()` max so future dates can't be selected.
- **Frontend profile** (`Profile.tsx`): adds `calculateAge()`, renders Age as read-only computed field, adds Edit Date of Birth button that opens the native picker via `showPicker()`, and confirms the change via Save/Cancel before calling `updateMember`.
- **AuthContext**: adds `refreshMember()` so consumers can refetch member data after mutations without reloading the page; the mount-time fetch now reuses it.
- **Bruno**: request/environment files updated for the new field and renamed `Login` → `Login and Get Token`; new `Return Authenticated Member.bru`.
- **Tests**: `MemberRepositoryTest`, `MemberServiceTest`, `WorkoutRepositoryTest`, `WorkoutServiceTest` updated to use `setDateOfBirth(LocalDate.of(...))`.

## Testing

- **Old behavior**: members had a static `age` integer that drifted out of date as time passed and required manual updates.
- **New behavior**: members store an immutable `date_of_birth`; the UI computes age on render so it's always current. Editing DOB on the Profile page opens the native calendar, requires explicit Save confirmation (the picker fires `change` while users navigate years/months, so we don't auto-submit), and refreshes the displayed age via `AuthContext.refreshMember()` without a full reload.
- Backend test suite passes (`./gradlew test`).
- Manually verified: signup with new DOB, profile age renders correctly, Edit Date of Birth picker opens, Save commits the update, Cancel discards.

## Screenshots

- *To be added: signup DOB field and Profile Edit Date of Birth flow (picker open, Save/Cancel row).*

## Additional Comments

- Existing dev rows had `age` populated but no `date_of_birth`. Since dev only had 2 rows, the column was added as `NOT NULL` and rows were backfilled manually rather than using a temporary nullable column. If this migration is ever applied to an environment with more data, the migration should be split: add nullable, backfill, then alter to NOT NULL.
- Refresh token work is tracked separately under FTRACK-9 and is out of scope for this PR.

# Checklist

- [x] All tests are passing
- [ ] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)