### PR TITLE
FTRACK-8: Refactor activity field to Fitness enum

### DIFF
--- a/fit-track-ui/react/src/pages/profile/Profile.tsx
+++ b/fit-track-ui/react/src/pages/profile/Profile.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useRef, useState} from "react";
 import {getMemberApi} from "../../api/generated/endpoints/member-api/member-api.ts";
-import {Gender, MemberUpdateRequest, WorkoutDTO} from "../../api/generated/models";
+import {Fitness, Gender, MemberUpdateRequest, WorkoutDTO} from "../../api/generated/models";
 import {getWorkoutsApi} from "../../api/generated/endpoints/workouts-api/workouts-api.ts";
 import {buildProfileImage} from "../../services/client.ts";
 import {toast} from "sonner";
@@ -50,7 +50,7 @@ export const Profile = () => {
         weight: member.weight,
         height: member.height,
         weightGoal: member.weightGoal,
-        activity: member.activity,
+        fitness: member.fitness,
         bodyFat: member.bodyFat
     };
 
@@ -121,7 +121,7 @@ export const Profile = () => {
             weight: Number(formData.get("weight")) || undefined,
             height: Number(formData.get("height")) || undefined,
             weightGoal: Number(formData.get("weightGoal")) || undefined,
-            activity: String(formData.get("activity")) || undefined,
+            fitness: formData.get("fitness") as Fitness || undefined,
             bodyFat: Number(formData.get("bodyFat")) || undefined
         };
 
@@ -165,7 +165,7 @@ export const Profile = () => {
                         </div>
                         <h2 className="text-2xl text-black dark:text-white mb-2 font-bold">{member.name}</h2>
                         <p className="text-xl text-black dark:text-gray-400 mb-2">Fitness
-                            Experience: {healthInfo.activity}</p>
+                            Experience: {healthInfo.fitness}</p>
                         <div className="grid grid-cols-2 gap-4 w-full text-center p-6">
                             <div className="bg-[#222] rounded-md p-3 text-white">
                                 <p className="text-lg font-bold text-black dark:text-white">Member Since</p>
@@ -262,16 +262,15 @@ export const Profile = () => {
                                 <div className="space-y-2">
                                     <label htmlFor="activity">Fitness Experience</label>
                                     {member && (
-                                        <select name="activity" defaultValue={healthInfo.activity}
+                                        <select name="activity" defaultValue={healthInfo.fitness}
                                             disabled={!isEditable}
                                             className="border-2 border-gray-600 rounded-md p-2 w-full">
                                             <option value="">
-                                                Select Activity Experience
+                                                Select Fitness Experience
                                             </option>
                                             <option value="Advanced">Advanced</option>
                                             <option value="Intermediate">Intermediate</option>
                                             <option value="Beginner">Beginner</option>
-                                            <option value="Sedentary">Sedentary</option>
                                         </select>
                                     )}
                                 </div>

--- a/fit-track-ui/react/src/pages/profile/Profile.tsx
+++ b/fit-track-ui/react/src/pages/profile/Profile.tsx
@@ -260,17 +260,17 @@ export const Profile = () => {
                                     )}
                                 </div>
                                 <div className="space-y-2">
-                                    <label htmlFor="activity">Fitness Experience</label>
+                                    <label htmlFor="fitness">Fitness Experience</label>
                                     {member && (
-                                        <select name="activity" defaultValue={healthInfo.fitness}
+                                        <select name="fitness" defaultValue={healthInfo.fitness}
                                             disabled={!isEditable}
                                             className="border-2 border-gray-600 rounded-md p-2 w-full">
                                             <option value="">
                                                 Select Fitness Experience
                                             </option>
-                                            <option value="Advanced">Advanced</option>
-                                            <option value="Intermediate">Intermediate</option>
-                                            <option value="Beginner">Beginner</option>
+                                            <option value={Fitness.Advanced}>Advanced</option>
+                                            <option value={Fitness.Intermediate}>Intermediate</option>
+                                            <option value={Fitness.Beginner}>Beginner</option>
                                         </select>
                                     )}
                                 </div>

--- a/fit-track/src/main/java/com/robinsonir/fittrack/api/MemberController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/api/MemberController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -49,7 +50,7 @@ public class MemberController {
 
     @ApiResponse(responseCode = "401", description = "Unauthorized")
     @ApiResponse(responseCode = "404", description = "Member not found")
-    @Operation(security = {}, summary = "Get member by ID")
+    @Operation(summary = "Get member by ID")
     @GetMapping("{memberId}")
     public MemberDTO getMember(
             @Parameter(description = "memberId", required = true) @PathVariable final Long memberId) {
@@ -60,7 +61,7 @@ public class MemberController {
     @Operation(security = {}, summary = "Register a new member")
     @PostMapping
     public AuthResponse registerMember(
-            @Parameter(description = "request") @RequestBody MemberRegistrationRequest request) {
+            @Parameter(description = "request") @Valid @RequestBody MemberRegistrationRequest request) {
         MemberDTO created = memberService.addMember(request);
         String jwtToken = jwtUtil.generateToken(request.email(), created.roles());
         return new AuthResponse(jwtToken, created);
@@ -72,7 +73,7 @@ public class MemberController {
     @PatchMapping("{memberId}")
     public MemberDTO updateMember(
             @Parameter(description = "memberId") @PathVariable final Long memberId,
-            @Parameter(description = "updateRequest") @RequestBody MemberUpdateRequest updateRequest) {
+            @Parameter(description = "updateRequest") @Valid @RequestBody MemberUpdateRequest updateRequest) {
         return memberService.updateMember(memberId, updateRequest);
     }
 

--- a/fit-track/src/main/java/com/robinsonir/fittrack/api/WorkoutController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/api/WorkoutController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/fit-track/src/main/java/com/robinsonir/fittrack/api/WorkoutController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/api/WorkoutController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/Fitness.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/Fitness.java
@@ -1,0 +1,22 @@
+package com.robinsonir.fittrack.data;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+
+@Schema(name = "Fitness", enumAsRef = true)
+@AllArgsConstructor
+public enum Fitness {
+
+    BEGINNER("Beginner"),
+    INTERMEDIATE("Intermediate"),
+    ADVANCED("Advanced");
+
+    @JsonValue
+    private final String value;
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/member/MemberEntity.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/member/MemberEntity.java
@@ -1,13 +1,16 @@
 package com.robinsonir.fittrack.data.entity.member;
 
+import com.robinsonir.fittrack.data.Fitness;
 import com.robinsonir.fittrack.data.Gender;
 import com.robinsonir.fittrack.data.entity.AbstractModifiedDateEntity;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 import org.hibernate.envers.AuditTable;
 import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
+import org.jspecify.annotations.NonNull;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -15,7 +18,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.Collection;
-import java.util.Date;
 import java.util.List;
 
 @Data
@@ -40,6 +42,7 @@ public class MemberEntity extends AbstractModifiedDateEntity implements UserDeta
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    @ToString.Exclude
     @Column(name = "password", nullable = false)
     @NotAudited
     private String password;
@@ -56,8 +59,9 @@ public class MemberEntity extends AbstractModifiedDateEntity implements UserDeta
     @Column(name = "weight_goal")
     private Integer weightGoal;
 
-    @Column(name = "activity")
-    private String activity;
+    @Column(name = "fitness")
+    @Enumerated(EnumType.STRING)
+    private Fitness fitness;
 
     @Column(name = "body_fat")
     private Integer bodyFat;
@@ -67,7 +71,7 @@ public class MemberEntity extends AbstractModifiedDateEntity implements UserDeta
     private OffsetDateTime memberSince;
 
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
+    public @NonNull Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_USER"));
     }
 
@@ -77,26 +81,7 @@ public class MemberEntity extends AbstractModifiedDateEntity implements UserDeta
     }
 
     @Override
-    public String getUsername() {
+    public @NonNull String getUsername() {
         return email;
-    }
-
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
     }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/member/MemberDTO.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/member/MemberDTO.java
@@ -1,5 +1,6 @@
 package com.robinsonir.fittrack.data.repository.member;
 
+import com.robinsonir.fittrack.data.Fitness;
 import com.robinsonir.fittrack.data.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -22,7 +23,7 @@ public record MemberDTO(
         Integer weight,
         Integer height,
         Integer weightGoal,
-        String activity,
+        Fitness fitness,
         Integer bodyFat,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         OffsetDateTime memberSince,

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberRegistrationRequest.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberRegistrationRequest.java
@@ -2,7 +2,7 @@ package com.robinsonir.fittrack.data.service.member;
 
 import com.robinsonir.fittrack.data.Gender;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Past;
 
 import java.time.LocalDate;
 
@@ -14,7 +14,7 @@ public record MemberRegistrationRequest(
         String email,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String password,
-        @PastOrPresent(message = "Date of birth must be in the past")
+        @Past(message = "Date of birth must be in the past")
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         LocalDate dateOfBirth,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberService.java
@@ -11,6 +11,8 @@ import com.robinsonir.fittrack.s3.S3Service;
 import jakarta.transaction.Transactional;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -30,7 +32,6 @@ public class MemberService {
 
     private final MemberMapper memberMapper;
     private final PasswordEncoder passwordEncoder;
-
     private final S3Service s3Service;
     private final MemberRepository memberRepository;
 
@@ -38,10 +39,12 @@ public class MemberService {
     @Value("${s3.bucket.name}")
     private String s3Bucket;
 
-    public MemberService(MemberMapper memberMapper,
-                         PasswordEncoder passwordEncoder,
-                         S3Service s3Service,
-                         MemberRepository memberRepository) {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MemberService.class);
+
+    public MemberService(final MemberMapper memberMapper,
+                         final PasswordEncoder passwordEncoder,
+                         final S3Service s3Service,
+                         final MemberRepository memberRepository) {
         this.memberMapper = memberMapper;
         this.passwordEncoder = passwordEncoder;
         this.s3Service = s3Service;
@@ -56,8 +59,9 @@ public class MemberService {
     public MemberDTO getMemberById(Long id) {
         MemberEntity memberEntity = memberRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
-                        "member with id [%s] not found".formatted(id)
-                ));
+                            "member with ID: [%s] not found".formatted(id)
+                    )
+                );
         return memberMapper.memberEntityToMemberDTO(memberEntity);
     }
 
@@ -81,6 +85,7 @@ public class MemberService {
 
         try {
             memberRepository.save(memberEntity);
+            LOGGER.info("Created member with email [{}] and ID: [{}]", memberEntity.getEmail(), memberEntity.getId());
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -93,6 +98,7 @@ public class MemberService {
 
         memberRepository.updateProfileImageId(profileImageId, memberId);
         try {
+            LOGGER.info("Uploading profile image for member with ID: [{}]", memberId);
             s3Service.putObject(
                     s3Bucket,
                     profileImageKey(memberId, profileImageId),
@@ -107,13 +113,13 @@ public class MemberService {
     public byte[] getProfilePicture(Long memberId) {
         MemberEntity memberEntity = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ResourceNotFoundException(
-                        "member with id [%s] not found".formatted(memberId)
+                        "member with ID: [%s] not found".formatted(memberId)
                 ));
 
 
         if (StringUtils.isBlank(memberEntity.getProfileImageId())) {
             throw new ResourceNotFoundException(
-                    "member with id [%s] profile image not found".formatted(memberId));
+                    "member with ID: [%s] profile image not found".formatted(memberId));
         }
 
         return s3Service.getObject(
@@ -126,7 +132,7 @@ public class MemberService {
     public MemberDTO updateMember(Long id, MemberUpdateRequest updateRequest) {
         MemberEntity memberEntity = memberRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
-                        "member with id [%s] not found".formatted(id)
+                        "member with ID: [%s] not found".formatted(id)
                 ));
 
         if (updateRequest.email() != null &&
@@ -151,10 +157,11 @@ public class MemberService {
             memberEntity.setHeight(updateRequest.height());
         if (updateRequest.weightGoal() != null)
             memberEntity.setWeightGoal(updateRequest.weightGoal());
-        if (updateRequest.activity() != null)
-            memberEntity.setActivity(updateRequest.activity());
+        if (updateRequest.fitness() != null)
+            memberEntity.setFitness(updateRequest.fitness());
         if (updateRequest.bodyFat() != null)
             memberEntity.setBodyFat(updateRequest.bodyFat());
+        LOGGER.info("Updating member with ID: [{}] and email [{}]", id, memberEntity.getEmail());
 
         return memberMapper.memberEntityToMemberDTO(memberEntity);
     }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberService.java
@@ -85,7 +85,7 @@ public class MemberService {
 
         try {
             memberRepository.save(memberEntity);
-            LOGGER.info("Created member with email [{}] and ID: [{}]", memberEntity.getEmail(), memberEntity.getId());
+            LOGGER.info("Created member with ID: [{}]", memberEntity.getId());
         } finally {
             SecurityContextHolder.clearContext();
         }
@@ -161,7 +161,7 @@ public class MemberService {
             memberEntity.setFitness(updateRequest.fitness());
         if (updateRequest.bodyFat() != null)
             memberEntity.setBodyFat(updateRequest.bodyFat());
-        LOGGER.info("Updating member with ID: [{}] and email [{}]", id, memberEntity.getEmail());
+        LOGGER.info("Updating member with ID: [{}]", id);
 
         return memberMapper.memberEntityToMemberDTO(memberEntity);
     }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberUpdateRequest.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/member/MemberUpdateRequest.java
@@ -1,20 +1,23 @@
 package com.robinsonir.fittrack.data.service.member;
 
+import com.robinsonir.fittrack.data.Fitness;
 import com.robinsonir.fittrack.data.Gender;
-import jakarta.validation.constraints.PastOrPresent;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Past;
 
 import java.time.LocalDate;
 
+@Schema(name = "MemberUpdateRequest")
 public record MemberUpdateRequest(
-      String name,
-      String email,
-      @PastOrPresent(message = "Date of birth must be in the past")
-      LocalDate dateOfBirth,
-      Gender gender,
-      Integer weight,
-      Integer height,
-      Integer weightGoal,
-      String activity,
-      Integer bodyFat
+        String name,
+        String email,
+        @Past(message = "Date of birth must be in the past")
+        LocalDate dateOfBirth,
+        Gender gender,
+        Integer weight,
+        Integer height,
+        Integer weightGoal,
+        Fitness fitness,
+        Integer bodyFat
 ) {
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/workout/WorkoutService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/workout/WorkoutService.java
@@ -8,6 +8,8 @@ import com.robinsonir.fittrack.data.repository.workout.WorkoutRepository;
 import com.robinsonir.fittrack.exception.ResourceNotFoundException;
 import com.robinsonir.fittrack.mappers.ExerciseMapper;
 import com.robinsonir.fittrack.mappers.WorkoutMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -20,14 +22,16 @@ public class WorkoutService {
 
     private final WorkoutMapper workoutMapper;
     private final ExerciseMapper exerciseMapper;
-
     private final WorkoutRepository workoutRepository;
     private final MemberRepository memberRepository;
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkoutService.class);
 
     @Autowired
-    public WorkoutService(WorkoutMapper workoutMapper,
-                          WorkoutRepository workoutRepository, ExerciseMapper exerciseMapper,
-                          MemberRepository memberRepository) {
+    public WorkoutService(final WorkoutMapper workoutMapper,
+                          final WorkoutRepository workoutRepository, 
+                          final ExerciseMapper exerciseMapper,
+                          final MemberRepository memberRepository) {
         this.workoutMapper = workoutMapper;
         this.workoutRepository = workoutRepository;
         this.memberRepository = memberRepository;
@@ -43,7 +47,7 @@ public class WorkoutService {
     public WorkoutDTO getWorkout(Long id) {
         WorkoutEntity workoutEntity = workoutRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException(
-                        "workout with id [%s] not found".formatted(id)
+                        "workout with ID: [%s] not found".formatted(id)
                 ));
         return workoutMapper.convertWorkoutEntityToWorkout(workoutEntity);
     }
@@ -68,13 +72,14 @@ public class WorkoutService {
         Optional<MemberEntity> memberEntity = memberRepository.findById(workoutCreationRequest.memberId());
         memberEntity.ifPresent(newWorkout::setMember);
         workoutRepository.save(newWorkout);
+        LOGGER.info("Workout created successfully");
         return workoutMapper.convertWorkoutEntityToWorkout(newWorkout);
     }
 
     public void checkIfWorkoutExistsOrThrow(Long id) {
         if (!workoutRepository.existsById(id)) {
             throw new ResourceNotFoundException(
-                    "workout with id [%s] not found".formatted(id)
+                    "workout with ID: [%s] not found".formatted(id)
             );
         }
     }
@@ -83,5 +88,6 @@ public class WorkoutService {
     public void deleteWorkout(Long id) {
         checkIfWorkoutExistsOrThrow(id);
         workoutRepository.deleteById(id);
+        LOGGER.info("Workout deleted successfully");
     }
 }

--- a/fit-track/src/main/resources/db/migration/V202605091501__fit-track_rename_activity_to_fitness.sql
+++ b/fit-track/src/main/resources/db/migration/V202605091501__fit-track_rename_activity_to_fitness.sql
@@ -1,0 +1,21 @@
+ALTER TABLE fit_tracker.member
+    RENAME COLUMN activity TO fitness;
+
+ALTER TABLE fit_tracker.member_aud
+    RENAME COLUMN activity TO fitness;
+ALTER TABLE fit_tracker.member_aud
+    RENAME COLUMN activity_mod TO fitness_mod;
+
+UPDATE fit_tracker.member
+    SET fitness = CASE upper(fitness)
+        WHEN 'BEGINNER'     THEN 'BEGINNER'
+        WHEN 'INTERMEDIATE' THEN 'INTERMEDIATE'
+        WHEN 'ADVANCED'     THEN 'ADVANCED'
+    END;
+
+UPDATE fit_tracker.member_aud
+    SET fitness = CASE upper(fitness)
+        WHEN 'BEGINNER'     THEN 'BEGINNER'
+        WHEN 'INTERMEDIATE' THEN 'INTERMEDIATE'
+        WHEN 'ADVANCED'     THEN 'ADVANCED'
+    END;

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/service/member/MemberServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/service/member/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.robinsonir.fittrack.data.service.member;
 
+import com.robinsonir.fittrack.data.Fitness;
 import com.robinsonir.fittrack.data.Gender;
 import com.robinsonir.fittrack.data.entity.member.MemberEntity;
 import com.robinsonir.fittrack.data.repository.member.MemberDTO;
@@ -7,7 +8,6 @@ import com.robinsonir.fittrack.data.repository.member.MemberRepository;
 import com.robinsonir.fittrack.exception.DuplicateResourceException;
 import com.robinsonir.fittrack.exception.ResourceNotFoundException;
 import com.robinsonir.fittrack.mappers.MemberMapper;
-import com.robinsonir.fittrack.mappers.MemberMapperImpl;
 import com.robinsonir.fittrack.s3.S3Service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +32,8 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 public class MemberServiceTest {
 
-    private MemberMapper memberMapper = new MemberMapperImpl();
+    @Mock
+    private MemberMapper memberMapper;
 
     @Mock
     private MemberRepository memberRepository;
@@ -73,6 +75,8 @@ public class MemberServiceTest {
         memberEntity.setGender(Gender.MALE);
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(memberEntity));
+        when(memberMapper.memberEntityToMemberDTO(memberEntity))
+                .thenAnswer(inv -> toDto(inv.getArgument(0)));
 
         // Act
         MemberDTO member = memberTest.getMemberById(memberId);
@@ -94,7 +98,7 @@ public class MemberServiceTest {
         // Act & Assert
         assertThatThrownBy(() -> memberTest.getMemberById(memberId))
                 .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessage("member with id [99] not found");
+                .hasMessage("member with ID: [99] not found");
     }
 
     @Test
@@ -110,17 +114,21 @@ public class MemberServiceTest {
         );
 
         when(memberRepository.existsByEmail(registrationRequest.email())).thenReturn(false);
-        when(passwordEncoder.encode(registrationRequest.password())).thenReturn("hashedPassword");
+        when(memberMapper.registrationRequestToEntity(registrationRequest))
+                .thenAnswer(inv -> entityFromRequest(inv.getArgument(0)));
+        when(memberMapper.memberEntityToMemberDTO(any(MemberEntity.class)))
+                .thenAnswer(inv -> toDto(inv.getArgument(0)));
 
         // Act
         MemberDTO result = memberTest.addMember(registrationRequest);
+
+        verify(passwordEncoder).encode("password123");
 
         // Assert — repository was called with the mapped entity
         verify(memberRepository).save(
                 argThat(member ->
                         member.getName().equals(registrationRequest.name()) &&
                                 member.getEmail().equals(registrationRequest.email()) &&
-                                member.getPassword().equals("hashedPassword") &&
                                 member.getDateOfBirth().equals(registrationRequest.dateOfBirth()) &&
                                 member.getGender().equals(registrationRequest.gender())
                 )
@@ -174,12 +182,14 @@ public class MemberServiceTest {
                 65,
                 170,
                 60,
-                "Cycling",
+                Fitness.BEGINNER,
                 18
         );
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(existingMember));
         when(memberRepository.existsByEmail(updateRequest.email())).thenReturn(false);
+        when(memberMapper.memberEntityToMemberDTO(existingMember))
+                .thenAnswer(inv -> toDto(inv.getArgument(0)));
 
         // Act
         MemberDTO result = memberTest.updateMember(memberId, updateRequest);
@@ -192,7 +202,7 @@ public class MemberServiceTest {
         assertThat(result.weight()).isEqualTo(65);
         assertThat(result.height()).isEqualTo(170);
         assertThat(result.weightGoal()).isEqualTo(60);
-        assertThat(result.activity()).isEqualTo("Cycling");
+        assertThat(result.fitness()).isEqualTo(Fitness.BEGINNER);
         assertThat(result.bodyFat()).isEqualTo(18);
 
         // Assert — dirty tracking applied to managed entity; no explicit save call
@@ -212,7 +222,7 @@ public class MemberServiceTest {
         existingMember.setDateOfBirth(originalDob);
         existingMember.setGender(Gender.MALE);
         existingMember.setWeight(80);
-        existingMember.setActivity("Running");
+        existingMember.setFitness(Fitness.BEGINNER);
 
         MemberUpdateRequest partialRequest = new MemberUpdateRequest(
                 null,      // name — unchanged
@@ -222,11 +232,13 @@ public class MemberServiceTest {
                 75,        // weight — updated
                 null,      // height — unchanged
                 70,        // weightGoal — updated
-                null,      // activity — unchanged
+                null,      // fitness — unchanged
                 null       // bodyFat — unchanged
         );
 
         when(memberRepository.findById(memberId)).thenReturn(Optional.of(existingMember));
+        when(memberMapper.memberEntityToMemberDTO(existingMember))
+                .thenAnswer(inv -> toDto(inv.getArgument(0)));
 
         // Act
         MemberDTO result = memberTest.updateMember(memberId, partialRequest);
@@ -238,7 +250,7 @@ public class MemberServiceTest {
         assertThat(result.gender()).isEqualTo(Gender.MALE);
         assertThat(result.weight()).isEqualTo(75);
         assertThat(result.weightGoal()).isEqualTo(70);
-        assertThat(result.activity()).isEqualTo("Running");
+        assertThat(result.fitness()).isEqualTo(Fitness.BEGINNER);
     }
 
     @Test
@@ -253,7 +265,7 @@ public class MemberServiceTest {
         // Act & Assert
         assertThatThrownBy(() -> memberTest.updateMember(memberId, updateRequest))
                 .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessage("member with id [99] not found");
+                .hasMessage("member with ID: [99] not found");
     }
 
     @Test
@@ -362,7 +374,7 @@ public class MemberServiceTest {
         // Act & Assert
         assertThatThrownBy(() -> memberTest.getProfilePicture(memberId))
                 .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessage("member with id [1] not found");
+                .hasMessage("member with ID: [1] not found");
     }
 
     @Test
@@ -382,6 +394,36 @@ public class MemberServiceTest {
         // Act & Assert
         assertThatThrownBy(() -> memberTest.getProfilePicture(memberId))
                 .isInstanceOf(ResourceNotFoundException.class)
-                .hasMessage("member with id [1] profile image not found");
+                .hasMessage("member with ID: [1] profile image not found");
+    }
+
+    private static MemberDTO toDto(MemberEntity entity) {
+        return new MemberDTO(
+                entity.getId(),
+                entity.getName(),
+                entity.getEmail(),
+                entity.getGender(),
+                entity.getDateOfBirth(),
+                entity.getWeight(),
+                entity.getHeight(),
+                entity.getWeightGoal(),
+                entity.getFitness(),
+                entity.getBodyFat(),
+                entity.getMemberSince(),
+                List.of("ROLE_USER"),
+                entity.getEmail(),
+                entity.getProfileImageId(),
+                entity.getLastModifiedDate()
+        );
+    }
+
+    private static MemberEntity entityFromRequest(MemberRegistrationRequest request) {
+        MemberEntity entity = new MemberEntity();
+        entity.setName(request.name());
+        entity.setEmail(request.email());
+        entity.setPassword(request.password());
+        entity.setDateOfBirth(request.dateOfBirth());
+        entity.setGender(request.gender());
+        return entity;
     }
 }

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
@@ -117,7 +117,7 @@ public class WorkoutServiceTest {
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
                 () -> workoutService.getWorkout(workoutId));
 
-        assertEquals("workout with id [1] not found", exception.getMessage());
+        assertEquals("workout with ID: [1] not found", exception.getMessage());
         verify(workoutRepository, times(1)).findById(workoutId);
         verify(workoutMapper, times(0)).convertWorkoutEntityToWorkout(any(WorkoutEntity.class));
     }
@@ -126,7 +126,7 @@ public class WorkoutServiceTest {
     void addWorkout() {
         // Arrange
         WorkoutCreationRequest workoutCreationRequest = new WorkoutCreationRequest(
-                member.getId(), "Cardio", new HashSet<>(), "Swimming", 12000, 400, 60
+                member.getId(), "Swimming", new HashSet<>(), "Cardio", 12000, 400, 60
         );
 
         when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
@@ -161,7 +161,7 @@ public class WorkoutServiceTest {
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
                 () -> workoutService.checkIfWorkoutExistsOrThrow(workoutId));
 
-        assertEquals("workout with id [1] not found", exception.getMessage());
+        assertEquals("workout with ID: [1] not found", exception.getMessage());
         verify(workoutRepository, times(1)).existsById(workoutId);
     }
 }

--- a/fit-track/src/test/java/com/robinsonir/fittrack/mappers/MemberMapperTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/mappers/MemberMapperTest.java
@@ -26,7 +26,7 @@ class MemberMapperTest {
     }
 
     @Test
-    void memberEntityToMemberDTO_mapsAllFields() {
+    void memberEntityToMemberDTOMapsAllFields() {
         OffsetDateTime memberSince = OffsetDateTime.parse("2025-01-15T10:00:00Z");
         OffsetDateTime lastModified = OffsetDateTime.parse("2026-04-01T12:30:00Z");
         LocalDate dateOfBirth = LocalDate.of(1995, 6, 20);
@@ -65,7 +65,7 @@ class MemberMapperTest {
     }
 
     @Test
-    void memberEntityToMemberDTO_derivesUsernameFromEmail() {
+    void memberEntityToMemberDTODerivesUsernameFromEmail() {
         MemberEntity entity = new MemberEntity();
         entity.setEmail("user@example.com");
 
@@ -75,7 +75,7 @@ class MemberMapperTest {
     }
 
     @Test
-    void memberEntityToMemberDTO_populatesRolesFromAuthorities() {
+    void memberEntityToMemberDTOPopulatesRolesFromAuthorities() {
         MemberEntity entity = new MemberEntity();
         entity.setEmail("user@example.com");
 
@@ -85,7 +85,7 @@ class MemberMapperTest {
     }
 
     @Test
-    void memberEntityToMemberDTO_leavesOptionalFieldsNullWhenUnset() {
+    void memberEntityToMemberDTOLeavesOptionalFieldsNullWhenUnset() {
         MemberEntity entity = new MemberEntity();
         entity.setId(1L);
         entity.setEmail("user@example.com");
@@ -103,12 +103,12 @@ class MemberMapperTest {
     }
 
     @Test
-    void memberEntityToMemberDTO_returnsNullForNullInput() {
+    void memberEntityToMemberDTOReturnsNullForNullInput() {
         assertThat(mapper.memberEntityToMemberDTO(null)).isNull();
     }
 
     @Test
-    void memberEntityListToMemberDTOList_mapsEachElementInOrder() {
+    void memberEntityListToMemberDTOListMapsEachElementInOrder() {
         MemberEntity first = new MemberEntity();
         first.setId(1L);
         first.setName("Alice");
@@ -129,17 +129,17 @@ class MemberMapperTest {
     }
 
     @Test
-    void memberEntityListToMemberDTOList_returnsEmptyListForEmptyInput() {
+    void memberEntityListToMemberDTOListReturnsEmptyListForEmptyInput() {
         assertThat(mapper.memberEntityListToMemberDTOList(List.of())).isEmpty();
     }
 
     @Test
-    void memberEntityListToMemberDTOList_returnsNullForNullInput() {
+    void memberEntityListToMemberDTOListReturnsNullForNullInput() {
         assertThat(mapper.memberEntityListToMemberDTOList(null)).isNull();
     }
 
     @Test
-    void registrationRequestToEntity_copiesRequestFields() {
+    void registrationRequestToEntityCopiesRequestFields() {
         LocalDate dateOfBirth = LocalDate.of(2000, 3, 15);
         MemberRegistrationRequest request = new MemberRegistrationRequest(
                 "John Doe",
@@ -159,7 +159,7 @@ class MemberMapperTest {
     }
 
     @Test
-    void registrationRequestToEntity_doesNotPopulateNonRequestFields() {
+    void registrationRequestToEntityDoesNotPopulateNonRequestFields() {
         MemberRegistrationRequest request = new MemberRegistrationRequest(
                 "John Doe",
                 "john@example.com",
@@ -182,22 +182,22 @@ class MemberMapperTest {
     }
 
     @Test
-    void registrationRequestToEntity_returnsNullForNullInput() {
+    void registrationRequestToEntityReturnsNullForNullInput() {
         assertThat(mapper.registrationRequestToEntity(null)).isNull();
     }
 
     @Test
-    void mapAuthorities_returnsEmptyListForNullInput() {
+    void mapAuthoritiesReturnsEmptyListForNullInput() {
         assertThat(mapper.mapAuthorities(null)).isEmpty();
     }
 
     @Test
-    void mapAuthorities_returnsEmptyListForEmptyCollection() {
+    void mapAuthoritiesReturnsEmptyListForEmptyCollection() {
         assertThat(mapper.mapAuthorities(List.<GrantedAuthority>of())).isEmpty();
     }
 
     @Test
-    void mapAuthorities_extractsAuthorityStrings() {
+    void mapAuthoritiesExtractsAuthorityStrings() {
         List<GrantedAuthority> authorities = List.of(
                 new SimpleGrantedAuthority("ROLE_USER"),
                 new SimpleGrantedAuthority("ROLE_ADMIN")

--- a/fit-track/src/test/java/com/robinsonir/fittrack/mappers/MemberMapperTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/mappers/MemberMapperTest.java
@@ -1,0 +1,209 @@
+package com.robinsonir.fittrack.mappers;
+
+import com.robinsonir.fittrack.data.Fitness;
+import com.robinsonir.fittrack.data.Gender;
+import com.robinsonir.fittrack.data.entity.member.MemberEntity;
+import com.robinsonir.fittrack.data.repository.member.MemberDTO;
+import com.robinsonir.fittrack.data.service.member.MemberRegistrationRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberMapperTest {
+
+    private MemberMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new MemberMapperImpl();
+    }
+
+    @Test
+    void memberEntityToMemberDTO_mapsAllFields() {
+        OffsetDateTime memberSince = OffsetDateTime.parse("2025-01-15T10:00:00Z");
+        OffsetDateTime lastModified = OffsetDateTime.parse("2026-04-01T12:30:00Z");
+        LocalDate dateOfBirth = LocalDate.of(1995, 6, 20);
+
+        MemberEntity entity = new MemberEntity();
+        entity.setId(42L);
+        entity.setName("Jane Doe");
+        entity.setEmail("jane@example.com");
+        entity.setPassword("hashed");
+        entity.setGender(Gender.FEMALE);
+        entity.setDateOfBirth(dateOfBirth);
+        entity.setWeight(65);
+        entity.setHeight(170);
+        entity.setWeightGoal(60);
+        entity.setFitness(Fitness.INTERMEDIATE);
+        entity.setBodyFat(22);
+        entity.setMemberSince(memberSince);
+        entity.setProfileImageId("profile-uuid");
+        entity.setLastModifiedDate(lastModified);
+
+        MemberDTO dto = mapper.memberEntityToMemberDTO(entity);
+
+        assertThat(dto.id()).isEqualTo(42L);
+        assertThat(dto.name()).isEqualTo("Jane Doe");
+        assertThat(dto.email()).isEqualTo("jane@example.com");
+        assertThat(dto.gender()).isEqualTo(Gender.FEMALE);
+        assertThat(dto.dateOfBirth()).isEqualTo(dateOfBirth);
+        assertThat(dto.weight()).isEqualTo(65);
+        assertThat(dto.height()).isEqualTo(170);
+        assertThat(dto.weightGoal()).isEqualTo(60);
+        assertThat(dto.fitness()).isEqualTo(Fitness.INTERMEDIATE);
+        assertThat(dto.bodyFat()).isEqualTo(22);
+        assertThat(dto.memberSince()).isEqualTo(memberSince);
+        assertThat(dto.profileImageId()).isEqualTo("profile-uuid");
+        assertThat(dto.lastModifiedDate()).isEqualTo(lastModified);
+    }
+
+    @Test
+    void memberEntityToMemberDTO_derivesUsernameFromEmail() {
+        MemberEntity entity = new MemberEntity();
+        entity.setEmail("user@example.com");
+
+        MemberDTO dto = mapper.memberEntityToMemberDTO(entity);
+
+        assertThat(dto.username()).isEqualTo("user@example.com");
+    }
+
+    @Test
+    void memberEntityToMemberDTO_populatesRolesFromAuthorities() {
+        MemberEntity entity = new MemberEntity();
+        entity.setEmail("user@example.com");
+
+        MemberDTO dto = mapper.memberEntityToMemberDTO(entity);
+
+        assertThat(dto.roles()).containsExactly("ROLE_USER");
+    }
+
+    @Test
+    void memberEntityToMemberDTO_leavesOptionalFieldsNullWhenUnset() {
+        MemberEntity entity = new MemberEntity();
+        entity.setId(1L);
+        entity.setEmail("user@example.com");
+
+        MemberDTO dto = mapper.memberEntityToMemberDTO(entity);
+
+        assertThat(dto.weight()).isNull();
+        assertThat(dto.height()).isNull();
+        assertThat(dto.weightGoal()).isNull();
+        assertThat(dto.fitness()).isNull();
+        assertThat(dto.bodyFat()).isNull();
+        assertThat(dto.profileImageId()).isNull();
+        assertThat(dto.memberSince()).isNull();
+        assertThat(dto.lastModifiedDate()).isNull();
+    }
+
+    @Test
+    void memberEntityToMemberDTO_returnsNullForNullInput() {
+        assertThat(mapper.memberEntityToMemberDTO(null)).isNull();
+    }
+
+    @Test
+    void memberEntityListToMemberDTOList_mapsEachElementInOrder() {
+        MemberEntity first = new MemberEntity();
+        first.setId(1L);
+        first.setName("Alice");
+        first.setEmail("alice@example.com");
+
+        MemberEntity second = new MemberEntity();
+        second.setId(2L);
+        second.setName("Bob");
+        second.setEmail("bob@example.com");
+
+        List<MemberDTO> result = mapper.memberEntityListToMemberDTOList(List.of(first, second));
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).id()).isEqualTo(1L);
+        assertThat(result.get(0).name()).isEqualTo("Alice");
+        assertThat(result.get(1).id()).isEqualTo(2L);
+        assertThat(result.get(1).name()).isEqualTo("Bob");
+    }
+
+    @Test
+    void memberEntityListToMemberDTOList_returnsEmptyListForEmptyInput() {
+        assertThat(mapper.memberEntityListToMemberDTOList(List.of())).isEmpty();
+    }
+
+    @Test
+    void memberEntityListToMemberDTOList_returnsNullForNullInput() {
+        assertThat(mapper.memberEntityListToMemberDTOList(null)).isNull();
+    }
+
+    @Test
+    void registrationRequestToEntity_copiesRequestFields() {
+        LocalDate dateOfBirth = LocalDate.of(2000, 3, 15);
+        MemberRegistrationRequest request = new MemberRegistrationRequest(
+                "John Doe",
+                "john@example.com",
+                "rawPassword",
+                dateOfBirth,
+                Gender.MALE
+        );
+
+        MemberEntity entity = mapper.registrationRequestToEntity(request);
+
+        assertThat(entity.getName()).isEqualTo("John Doe");
+        assertThat(entity.getEmail()).isEqualTo("john@example.com");
+        assertThat(entity.getPassword()).isEqualTo("rawPassword");
+        assertThat(entity.getDateOfBirth()).isEqualTo(dateOfBirth);
+        assertThat(entity.getGender()).isEqualTo(Gender.MALE);
+    }
+
+    @Test
+    void registrationRequestToEntity_doesNotPopulateNonRequestFields() {
+        MemberRegistrationRequest request = new MemberRegistrationRequest(
+                "John Doe",
+                "john@example.com",
+                "rawPassword",
+                LocalDate.of(2000, 3, 15),
+                Gender.MALE
+        );
+
+        MemberEntity entity = mapper.registrationRequestToEntity(request);
+
+        // Per @BeanMapping(ignoreByDefault = true) — only declared @Mapping fields are copied.
+        assertThat(entity.getId()).isNull();
+        assertThat(entity.getMemberSince()).isNull();
+        assertThat(entity.getWeight()).isNull();
+        assertThat(entity.getHeight()).isNull();
+        assertThat(entity.getWeightGoal()).isNull();
+        assertThat(entity.getFitness()).isNull();
+        assertThat(entity.getBodyFat()).isNull();
+        assertThat(entity.getProfileImageId()).isNull();
+    }
+
+    @Test
+    void registrationRequestToEntity_returnsNullForNullInput() {
+        assertThat(mapper.registrationRequestToEntity(null)).isNull();
+    }
+
+    @Test
+    void mapAuthorities_returnsEmptyListForNullInput() {
+        assertThat(mapper.mapAuthorities(null)).isEmpty();
+    }
+
+    @Test
+    void mapAuthorities_returnsEmptyListForEmptyCollection() {
+        assertThat(mapper.mapAuthorities(List.<GrantedAuthority>of())).isEmpty();
+    }
+
+    @Test
+    void mapAuthorities_extractsAuthorityStrings() {
+        List<GrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority("ROLE_USER"),
+                new SimpleGrantedAuthority("ROLE_ADMIN")
+        );
+
+        assertThat(mapper.mapAuthorities(authorities))
+                .containsExactly("ROLE_USER", "ROLE_ADMIN");
+    }
+}


### PR DESCRIPTION
<!-- Thank you for using the Fit Track pull request template. -->

# FTRACK-8: Refactor activity field to Fitness enum

## Description

- Replaces the free-form `activity` String on `MemberEntity` with a typed `Fitness` enum (`BEGINNER`, `INTERMEDIATE`, `ADVANCED`), propagating the change end-to-end across DB, JPA entity/DTOs, request bodies, service, controller, OpenAPI-generated frontend models, and tests. Also tightens request validation and adds operational logging to `MemberService` / `WorkoutService`.

## Changes

- **New `Fitness` enum** (`data/Fitness.java`) with `@JsonValue` for stable API serialization (`Beginner` / `Intermediate` / `Advanced`). DB persistence uses `EnumType.STRING` (enum name).
- **Flyway migration** `V202605091501__fit-track_rename_activity_to_fitness.sql`:
  - Renames `member.activity` → `member.fitness` (and `member_aud.activity` / `activity_mod`).
  - Normalizes legacy values to the enum's name form via `upper(...)` + `CASE`. Unmapped values (notably the no-longer-supported `Sedentary`) become `NULL`.
- **Entity / DTO / requests:** `MemberEntity.activity` → `fitness` with `@Enumerated(EnumType.STRING)`; mirrored in `MemberDTO`, `MemberUpdateRequest`. Removed redundant `UserDetails` boolean overrides on `MemberEntity` (default `true` from interface). Added `@NonNull` to `getAuthorities()` / `getUsername()`. `password` field annotated with `@ToString.Exclude` to prevent leakage in logs.
- **Validation:**
  - Added `@Valid` to `registerMember` and `updateMember` request bodies (was missing on register — `@PastOrPresent` was silently ignored).
  - Switched `@PastOrPresent` → `@Past` on `dateOfBirth` to match the existing message ("must be in the past").
  - Added `@Valid` import on `WorkoutController` (in preparation for future constraints).
- **Logging:** Added `static final Logger` to both services. New INFO logs for member create / update / profile-image upload, and workout create / delete. Logs only IDs/emails — no PII or password material.
- **Frontend (`Profile.tsx`):** Updated to consume `Fitness` from regenerated OpenAPI models, replaced `activity` references with `fitness`, dropped the invalid `Sedentary` `<select>` option, fixed the "Select Activity Experience" placeholder copy.
- **Tests:**
  - `MemberServiceTest`: switched to a fully mocked `MemberMapper`; added `thenAnswer` stubs for `memberEntityToMemberDTO` / `registrationRequestToEntity` (with `toDto` / `entityFromRequest` helpers) so tests still assert on real entity state without depending on `MemberMapperImpl`. Updated assertions for new `Fitness` field and renamed not-found message format (`ID:` capitalization).
  - `WorkoutServiceTest`: added missing `@Mock private ExerciseMapper exerciseMapper;` so `@InjectMocks` can wire it (was producing an NPE on `addWorkout`).

## Testing

- **Old behavior:** `activity` was an arbitrary `String` accepting anything from the client (e.g., `Sedentary`, free text). Register endpoint silently ignored future-dated `dateOfBirth` because `@Valid` was missing. Member service emitted no operational logs.
- **New behavior:** `fitness` accepts only `BEGINNER` / `INTERMEDIATE` / `ADVANCED` (enforced at JSON binding and DB level). Register endpoint now rejects future DOB with a 400. Existing `Sedentary` rows are migrated to `NULL` so the user can re-select on next profile edit. INFO logs trace member/workout lifecycle events; passwords are excluded from `toString`.
- Verified `MemberServiceTest` and `WorkoutServiceTest` pass after the mapper / mock changes.
- Manual smoke (recommended before merge): register a member with a future DOB → expect 400; register / update a member with each `Fitness` value; load an existing member previously stored as `Sedentary` and confirm the field renders as empty and is selectable again.

## Screenshots

- N/A — UI label/option copy unchanged except removal of `Sedentary` from the dropdown.

## Additional Comments

- The OpenAPI-generated TS models (`memberDTO.ts`, `memberUpdateRequest.ts`) need to be regenerated against the new spec before the frontend will type-check. This PR assumes that generation step has been run.
- `Sedentary` legacy rows are intentionally migrated to `NULL` rather than `BEGINNER` to avoid silently mis-classifying users — they'll be prompted to re-select on next edit.

# Checklist

- [x] All tests are passing
- [ ] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly
