### PR TITLE
FTRACK-9: Implement refresh token authentication

### DIFF
--- a/Bruno/Fitness Tracker/Login and Get Token.bru
+++ b/Bruno/Fitness Tracker/Login and Get Token.bru
@@ -18,5 +18,6 @@ body:json {
 }
 
 script:post-response {
-  bru.setEnvVar("bearerToken", res.getBody().jwtToken)
+  bru.setEnvVar("bearerToken", res.getBody().accessToken)
+  bru.setEnvVar("refreshToken", res.getBody().refreshToken)
 }

--- a/Bruno/Fitness Tracker/Refresh Token.bru
+++ b/Bruno/Fitness Tracker/Refresh Token.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Refresh Token
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}:8080/api/v1/auth/refresh
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "refreshToken": "{{refreshToken}}"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/Bruno/Fitness Tracker/environments/Fitness-Tracker-Dev.bru
+++ b/Bruno/Fitness Tracker/environments/Fitness-Tracker-Dev.bru
@@ -2,5 +2,6 @@ vars {
   baseUrl: http://fit-track-dev.eba-jpnjhwum.us-east-1.elasticbeanstalk.com
 }
 vars:secret [
-  bearerToken
+  bearerToken,
+  refreshToken
 ]

--- a/Bruno/Fitness Tracker/environments/Fitness-Tracker-Local.bru
+++ b/Bruno/Fitness Tracker/environments/Fitness-Tracker-Local.bru
@@ -2,5 +2,6 @@ vars {
   baseUrl: http://localhost
 }
 vars:secret [
-  bearerToken
+  bearerToken,
+  refreshToken
 ]

--- a/fit-track-ui/react/src/context/AuthContext.tsx
+++ b/fit-track-ui/react/src/context/AuthContext.tsx
@@ -51,7 +51,7 @@ const AuthProvider = ({children}: { children: any }) => {
             const refreshToken = response.refreshToken;
             if (accessToken !== undefined && refreshToken !== undefined) {
                 localStorage.setItem("access_token", accessToken);
-                localStorage.setItem("refresh_token", refreshToken)
+                localStorage.setItem("refresh_token", refreshToken);
             }
 
             setMember(response.member);
@@ -67,7 +67,7 @@ const AuthProvider = ({children}: { children: any }) => {
             const refreshToken = response.refreshToken;
             if (accessToken !== undefined && refreshToken !== undefined) {
                 localStorage.setItem("access_token", accessToken);
-                localStorage.setItem("refresh_token", refreshToken)
+                localStorage.setItem("refresh_token", refreshToken);
             }
             setMember(response.member);
         } catch (error) {

--- a/fit-track-ui/react/src/context/AuthContext.tsx
+++ b/fit-track-ui/react/src/context/AuthContext.tsx
@@ -1,5 +1,4 @@
 import {createContext, useContext, useEffect, useMemo, useState} from "react";
-import jwtDecode, {JwtPayload} from "jwt-decode";
 import {AuthRequest, MemberDTO, MemberRegistrationRequest} from "../api/generated/models";
 import {getMemberApi} from "../api/generated/endpoints/member-api/member-api.ts";
 import {getAuthApi} from "../api/generated/endpoints/auth-api/auth-api.ts";
@@ -7,10 +6,10 @@ import {getAuthApi} from "../api/generated/endpoints/auth-api/auth-api.ts";
 
 type AuthContextType = {
     member: MemberDTO | undefined;
+    loading: boolean;
     login: (authRequest: AuthRequest) => Promise<void>;
     register: (req: MemberRegistrationRequest) => Promise<void>;
     logOut: () => void;
-    isMemberAuthenticated: () => boolean;
     refreshMember: () => Promise<void>;
 };
 
@@ -21,6 +20,7 @@ const AuthProvider = ({children}: { children: any }) => {
     const {me: fetchMe, registerMember} = useMemo(() => getMemberApi(), []);
     const {login: performLogin} = getAuthApi();
     const [member, setMember] = useState<MemberDTO | undefined>();
+    const [loading, setLoading] = useState(true);
 
     const refreshMember = async (): Promise<void> => {
         const freshMember = await fetchMe();
@@ -28,33 +28,30 @@ const AuthProvider = ({children}: { children: any }) => {
     };
 
     useEffect(() => {
-        const token = localStorage.getItem("access_token");
-        if (!token) return;
-
-        try {
-            const decoded = jwtDecode<JwtPayload>(token);
-            if (!decoded.exp || Date.now() > decoded.exp * 1000) return;
-
-            fetchMe()
-                .then(setMember)
-                .catch(() => {
-                    localStorage.removeItem("access_token");
-                    setMember(undefined);
-                    window.location.href = "/login";
-                });
-        } catch {
-            localStorage.removeItem("access_token");
-            window.location.href = "/login";
+        if (!localStorage.getItem("access_token") && !localStorage.getItem("refresh_token")) {
+            setLoading(false);
+            return;
         }
+
+        fetchMe()
+            .then(setMember)
+            .catch(() => {
+                localStorage.removeItem("access_token");
+                localStorage.removeItem("refresh_token");
+                setMember(undefined);
+            })
+            .finally(() => setLoading(false));
     }, [fetchMe]);
 
 
     const login = async (authRequest: AuthRequest): Promise<void> => {
         try {
             const response = await performLogin(authRequest);
-            const jwtToken = response.jwtToken;
-            if (jwtToken !== undefined) {
-                localStorage.setItem("access_token", jwtToken);
+            const accessToken = response.accessToken;
+            const refreshToken = response.refreshToken;
+            if (accessToken !== undefined && refreshToken !== undefined) {
+                localStorage.setItem("access_token", accessToken);
+                localStorage.setItem("refresh_token", refreshToken)
             }
 
             setMember(response.member);
@@ -66,9 +63,11 @@ const AuthProvider = ({children}: { children: any }) => {
     const register = async (req: MemberRegistrationRequest): Promise<void> => {
         try {
             const response = await registerMember(req);
-            const jwtToken = response.jwtToken;
-            if (jwtToken !== undefined) {
-                localStorage.setItem("access_token", jwtToken);
+            const accessToken = response.accessToken;
+            const refreshToken = response.refreshToken;
+            if (accessToken !== undefined && refreshToken !== undefined) {
+                localStorage.setItem("access_token", accessToken);
+                localStorage.setItem("refresh_token", refreshToken)
             }
             setMember(response.member);
         } catch (error) {
@@ -78,30 +77,18 @@ const AuthProvider = ({children}: { children: any }) => {
 
     const logOut = () => {
         localStorage.removeItem("access_token");
+        localStorage.removeItem("refresh_token");
         setMember(undefined);
         window.location.href = "/login";
-    };
-
-    const isMemberAuthenticated = () => {
-        const token = localStorage.getItem("access_token");
-        if (!token) {
-            return false;
-        }
-        const decodeToken = jwtDecode<JwtPayload>(token);
-        if (!decodeToken.exp) {
-            return false;
-        }
-        const expiration = decodeToken.exp;
-        return Date.now() <= expiration * 1000;
     };
 
     return (
         <AuthContext.Provider value={{
             member: member,
+            loading,
             login: login,
             register: register,
             logOut,
-            isMemberAuthenticated,
             refreshMember,
         }}>
             {children}

--- a/fit-track-ui/react/src/services/client.ts
+++ b/fit-track-ui/react/src/services/client.ts
@@ -1,20 +1,59 @@
 import axios, {AxiosRequestConfig} from "axios";
+import jwtDecode, {JwtPayload} from "jwt-decode";
 
 
 const axiosInstance = axios.create({
     baseURL: import.meta.env.VITE_API_BASE_URL,
 });
-axiosInstance.interceptors.request.use(
-    (config) => {
-        const accessToken = localStorage.getItem("access_token");
 
+let refreshPromise: Promise<string | null> | null = null;
+
+export const refreshAccessToken = async (): Promise<string | null> => {
+    const refreshToken = localStorage.getItem("refresh_token");
+    if (!refreshToken) return null;
+
+    try {
+        const decoded = jwtDecode<JwtPayload>(refreshToken);
+        if (!decoded.exp || Date.now() > decoded.exp * 1000) return null;
+
+        const {data} = await axios.post(
+            `${import.meta.env.VITE_API_BASE_URL}/api/v1/auth/refresh`,
+            {refreshToken},
+            {headers: {"Content-Type": "application/json"}}
+        );
+
+        if (data.accessToken) {
+            localStorage.setItem("access_token", data.accessToken);
+            return data.accessToken;
+        }
+    } catch {
+        return null;
+    }
+    return null;
+};
+
+axiosInstance.interceptors.request.use(
+    async (config) => {
         if (config.data && config.data instanceof FormData) {
-            // If the request contains FormData, don't set the 'Content-Type', 
-            // the browser will handle it automatically
             delete config.headers["Content-Type"];
         } else {
-            // Default to 'application/json' if not FormData
             config.headers["Content-Type"] = "application/json";
+        }
+
+        let accessToken = localStorage.getItem("access_token");
+
+        if (accessToken) {
+            try {
+                const decoded = jwtDecode<JwtPayload>(accessToken);
+                if (decoded.exp && Date.now() > decoded.exp * 1000) {
+                    if (!refreshPromise) {
+                        refreshPromise = refreshAccessToken().finally(() => { refreshPromise = null; });
+                    }
+                    accessToken = await refreshPromise;
+                }
+            } catch {
+                accessToken = null;
+            }
         }
 
         if (accessToken) {

--- a/fit-track-ui/react/src/services/client.ts
+++ b/fit-track-ui/react/src/services/client.ts
@@ -14,7 +14,11 @@ export const refreshAccessToken = async (): Promise<string | null> => {
 
     try {
         const decoded = jwtDecode<JwtPayload>(refreshToken);
-        if (!decoded.exp || Date.now() > decoded.exp * 1000) return null;
+        if (!decoded.exp || Date.now() > decoded.exp * 1000) {
+            localStorage.removeItem("access_token");
+            localStorage.removeItem("refresh_token");
+            return null;
+        }
 
         const {data} = await axios.post(
             `${import.meta.env.VITE_API_BASE_URL}/api/v1/auth/refresh`,
@@ -26,7 +30,8 @@ export const refreshAccessToken = async (): Promise<string | null> => {
             localStorage.setItem("access_token", data.accessToken);
             return data.accessToken;
         }
-    } catch {
+    } catch (error) {
+        console.error("Failed to refresh access token:", error);
         return null;
     }
     return null;
@@ -50,6 +55,13 @@ axiosInstance.interceptors.request.use(
                         refreshPromise = refreshAccessToken().finally(() => { refreshPromise = null; });
                     }
                     accessToken = await refreshPromise;
+
+                    if (!accessToken) {
+                        localStorage.removeItem("access_token");
+                        localStorage.removeItem("refresh_token");
+                        window.location.href = "/login";
+                        return Promise.reject(new Error("Token refresh failed"));
+                    }
                 }
             } catch {
                 accessToken = null;

--- a/fit-track-ui/react/src/shared/ProtectedRoute.tsx
+++ b/fit-track-ui/react/src/shared/ProtectedRoute.tsx
@@ -4,16 +4,18 @@ import {useAuth} from "../context/AuthContext";
 
 const ProtectedRoute = ({children}: { children: any }) => {
 
-    const {isMemberAuthenticated} = useAuth();
+    const {member, loading} = useAuth();
     const navigate = useNavigate();
 
     useEffect(() => {
-        if (!isMemberAuthenticated()) {
+        if (!loading && !member) {
             navigate("/login");
         }
-    }, []);
+    }, [loading, member]);
 
-    return isMemberAuthenticated() ? children : "";
+    if (loading) return null;
+
+    return member ? children : null;
 };
 
 export default ProtectedRoute;

--- a/fit-track/src/main/java/com/robinsonir/fittrack/api/MemberController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/api/MemberController.java
@@ -63,8 +63,9 @@ public class MemberController {
     public AuthResponse registerMember(
             @Parameter(description = "request") @Valid @RequestBody MemberRegistrationRequest request) {
         MemberDTO created = memberService.addMember(request);
-        String jwtToken = jwtUtil.generateToken(request.email(), created.roles());
-        return new AuthResponse(jwtToken, created);
+        String accessToken = jwtUtil.generateToken(request.email(), created.roles());
+        String refreshToken = jwtUtil.generateRefreshToken(request.email());
+        return new AuthResponse(accessToken, refreshToken, created);
     }
 
 

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/SecurityFilterChainConfig.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/SecurityFilterChainConfig.java
@@ -43,7 +43,8 @@ public class SecurityFilterChainConfig {
                         .requestMatchers(
                         HttpMethod.POST,
                         "/api/v1/members",
-                        "/api/v1/auth/login"
+                        "/api/v1/auth/login",
+                        "/api/v1/auth/refresh"
                 )
                 .permitAll()
                 .requestMatchers(

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/AuthController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/AuthController.java
@@ -27,4 +27,10 @@ public class AuthController {
             @Parameter(description = "request") @RequestBody AuthRequest request) {
         return authService.login(request);
     }
+
+    @Operation(security = {}, summary = "Refresh token")
+    @PostMapping("refresh")
+    public RefreshResponse refresh(@Parameter(description = "request") @RequestBody RefreshRequest request) {
+        return authService.refreshToken(request.refreshToken());
+    }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/AuthResponse.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/AuthResponse.java
@@ -5,7 +5,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "AuthResponse")
 public record AuthResponse(
-        String jwtToken,
+        String accessToken,
+        String refreshToken,
         MemberDTO member
 ) {
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/AuthService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/AuthService.java
@@ -5,19 +5,22 @@ import com.robinsonir.fittrack.data.repository.member.MemberDTO;
 import com.robinsonir.fittrack.data.repository.member.MemberRepository;
 import com.robinsonir.fittrack.mappers.MemberMapper;
 import com.robinsonir.fittrack.security.jwt.JwtTokenUtil;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthService.class);
 
     private final AuthenticationManager authenticationManager;
 
@@ -41,16 +44,30 @@ public class AuthService {
     }
 
     public RefreshResponse refreshToken(String refreshToken) {
-        String subject = jwtUtil.getSubject(refreshToken);
-        // Load the user directly from the database
-        MemberEntity memberEntity = memberRepository.findByEmail(subject)
-                .orElseThrow(() -> new RuntimeException("User not found"));
-        if (!subject.equals(memberEntity.getUsername())) {
-            throw new RuntimeException("Invalid token");
+        if (refreshToken == null || refreshToken.trim().isEmpty()) {
+            throw new BadCredentialsException("Refresh token is required");
         }
 
-        MemberDTO member = memberMapper.memberEntityToMemberDTO(memberEntity);
-        var accessToken = jwtUtil.generateToken(member.username(), member.roles());
-        return new RefreshResponse(accessToken);
+        try {
+            String subject = jwtUtil.getSubject(refreshToken);
+            MemberEntity memberEntity = memberRepository.findByEmail(subject)
+                    .orElseThrow(() -> {
+                        LOGGER.warn("Token refresh attempt for non-existent user: {}", subject);
+                        return new BadCredentialsException("Invalid refresh token");
+                    });
+
+            if (!subject.equals(memberEntity.getUsername())) {
+                LOGGER.warn("Token refresh subject mismatch for user: {}", subject);
+                throw new BadCredentialsException("Invalid refresh token");
+            }
+
+            MemberDTO member = memberMapper.memberEntityToMemberDTO(memberEntity);
+            var accessToken = jwtUtil.generateToken(member.username(), member.roles());
+            LOGGER.info("Successful token refresh for user: {}", subject);
+            return new RefreshResponse(accessToken);
+        } catch (JwtException ex) {
+            LOGGER.warn("Invalid refresh token provided", ex);
+            throw new BadCredentialsException("Invalid refresh token", ex);
+        }
     }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/AuthService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/AuthService.java
@@ -2,14 +2,18 @@ package com.robinsonir.fittrack.security.auth;
 
 import com.robinsonir.fittrack.data.entity.member.MemberEntity;
 import com.robinsonir.fittrack.data.repository.member.MemberDTO;
+import com.robinsonir.fittrack.data.repository.member.MemberRepository;
 import com.robinsonir.fittrack.mappers.MemberMapper;
 import com.robinsonir.fittrack.security.jwt.JwtTokenUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +22,8 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
 
     private final MemberMapper memberMapper;
+
+    private final MemberRepository memberRepository;
 
     private final JwtTokenUtil jwtUtil;
 
@@ -29,7 +35,22 @@ public class AuthService {
         SecurityContextHolder.getContext().setAuthentication(authentication);
         MemberEntity principal = (MemberEntity) authentication.getPrincipal();
         MemberDTO member = memberMapper.memberEntityToMemberDTO(principal);
-        var token = jwtUtil.generateToken(member.username(), member.roles());
-        return new AuthResponse(token, member);
+        var accessToken = jwtUtil.generateToken(member.username(), member.roles());
+        var refreshToken = jwtUtil.generateRefreshToken(member.username());
+        return new AuthResponse(accessToken, refreshToken, member);
+    }
+
+    public RefreshResponse refreshToken(String refreshToken) {
+        String subject = jwtUtil.getSubject(refreshToken);
+        // Load the user directly from the database
+        MemberEntity memberEntity = memberRepository.findByEmail(subject)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        if (!subject.equals(memberEntity.getUsername())) {
+            throw new RuntimeException("Invalid token");
+        }
+
+        MemberDTO member = memberMapper.memberEntityToMemberDTO(memberEntity);
+        var accessToken = jwtUtil.generateToken(member.username(), member.roles());
+        return new RefreshResponse(accessToken);
     }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/RefreshRequest.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/RefreshRequest.java
@@ -1,0 +1,6 @@
+package com.robinsonir.fittrack.security.auth;
+
+public record RefreshRequest(
+        String refreshToken
+) {
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/RefreshResponse.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/auth/RefreshResponse.java
@@ -1,0 +1,9 @@
+package com.robinsonir.fittrack.security.auth;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "RefreshResponse")
+public record RefreshResponse(
+        String accessToken
+) {
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/jwt/JWTAuthenticationFilter.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/jwt/JWTAuthenticationFilter.java
@@ -75,7 +75,7 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (JwtException ex) {
             LOGGER.warn("Invalid or expired token", ex);
-            handlerExceptionResolver.resolveException(request, response, null, new BadCredentialsException("Invalid or expired token", ex));
+            filterChain.doFilter(request, response);
         }
     }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtil.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtil.java
@@ -16,11 +16,19 @@ import java.util.Map;
 @Service
 public class JwtTokenUtil {
 
-    @Value( "${jwt.secret-key}")
+    @Value("${jwt.secret-key}")
     private String secretKey;
 
-    public String generateToken(String subject, String... roles) {
-        return generateToken(subject, Map.of("scopes", roles));
+    public String generateRefreshToken(String subject) {
+
+        return Jwts
+                .builder()
+                .subject(subject)
+                .issuer("fittrack")
+                .issuedAt(Date.from(Instant.now()))
+                .expiration(Date.from(Instant.now().plus(30, ChronoUnit.DAYS)))
+                .signWith(getSigningKey())
+                .compact();
     }
 
     public String generateToken(String subject, List<String> roles) {
@@ -38,7 +46,7 @@ public class JwtTokenUtil {
                 .subject(subject)
                 .issuer("fittrack")
                 .issuedAt(Date.from(Instant.now()))
-                .expiration(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
+                .expiration(Date.from(Instant.now().plus(15, ChronoUnit.MINUTES)))
                 .signWith(getSigningKey())
                 .compact();
     }

--- a/fit-track/src/test/java/com/robinsonir/fittrack/security/auth/AuthServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/security/auth/AuthServiceTest.java
@@ -140,8 +140,8 @@ public class AuthServiceTest {
 
         // Act & Assert
         assertThatThrownBy(() -> authService.refreshToken(refreshToken))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("User not found");
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Invalid refresh token");
 
         verify(jwtUtil, never()).generateToken(anyString(), anyList());
     }
@@ -158,8 +158,39 @@ public class AuthServiceTest {
 
         // Act & Assert
         assertThatThrownBy(() -> authService.refreshToken(refreshToken))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("Invalid token");
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Invalid refresh token");
+
+        verify(jwtUtil, never()).generateToken(anyString(), anyList());
+    }
+
+    @Test
+    void refreshTokenThrowsWhenTokenIsNull() {
+        assertThatThrownBy(() -> authService.refreshToken(null))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Refresh token is required");
+
+        verify(jwtUtil, never()).getSubject(any());
+    }
+
+    @Test
+    void refreshTokenThrowsWhenTokenIsEmpty() {
+        assertThatThrownBy(() -> authService.refreshToken("  "))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Refresh token is required");
+
+        verify(jwtUtil, never()).getSubject(any());
+    }
+
+    @Test
+    void refreshTokenThrowsWhenTokenIsInvalid() {
+        // Arrange
+        when(jwtUtil.getSubject("malformed-token")).thenThrow(new io.jsonwebtoken.MalformedJwtException("Invalid JWT"));
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.refreshToken("malformed-token"))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Invalid refresh token");
 
         verify(jwtUtil, never()).generateToken(anyString(), anyList());
     }

--- a/fit-track/src/test/java/com/robinsonir/fittrack/security/auth/AuthServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/security/auth/AuthServiceTest.java
@@ -1,0 +1,166 @@
+package com.robinsonir.fittrack.security.auth;
+
+import com.robinsonir.fittrack.data.Gender;
+import com.robinsonir.fittrack.data.entity.member.MemberEntity;
+import com.robinsonir.fittrack.data.repository.member.MemberDTO;
+import com.robinsonir.fittrack.data.repository.member.MemberRepository;
+import com.robinsonir.fittrack.mappers.MemberMapper;
+import com.robinsonir.fittrack.security.jwt.JwtTokenUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private MemberMapper memberMapper;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private JwtTokenUtil jwtUtil;
+
+    private AuthService authService;
+
+    private MemberEntity memberEntity;
+    private MemberDTO memberDTO;
+
+    @BeforeEach
+    void setUp() {
+        authService = new AuthService(authenticationManager, memberMapper, memberRepository, jwtUtil);
+
+        memberEntity = new MemberEntity();
+        memberEntity.setId(1L);
+        memberEntity.setName("John Doe");
+        memberEntity.setEmail("john@example.com");
+        memberEntity.setPassword("hashedPassword");
+        memberEntity.setDateOfBirth(LocalDate.of(1995, 1, 1));
+        memberEntity.setGender(Gender.MALE);
+
+        memberDTO = new MemberDTO(
+                1L, "John Doe", "john@example.com", Gender.MALE,
+                LocalDate.of(1995, 1, 1), null, null, null, null, null,
+                OffsetDateTime.now(), List.of("ROLE_USER"), "john@example.com",
+                null, OffsetDateTime.now()
+        );
+    }
+
+    @Test
+    void loginReturnsAuthResponseWithTokens() {
+        // Arrange
+        AuthRequest request = new AuthRequest("john@example.com", "password123");
+        Authentication authentication = mock(Authentication.class);
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(memberEntity);
+        when(memberMapper.memberEntityToMemberDTO(memberEntity)).thenReturn(memberDTO);
+        when(jwtUtil.generateToken("john@example.com", List.of("ROLE_USER"))).thenReturn("access-token");
+        when(jwtUtil.generateRefreshToken("john@example.com")).thenReturn("refresh-token");
+
+        // Act
+        AuthResponse response = authService.login(request);
+
+        // Assert
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
+        assertThat(response.member()).isEqualTo(memberDTO);
+
+        verify(authenticationManager).authenticate(
+                argThat(token ->
+                        token.getPrincipal().equals("john@example.com") &&
+                                token.getCredentials().equals("password123")
+                )
+        );
+    }
+
+    @Test
+    void loginThrowsWhenCredentialsAreInvalid() {
+        // Arrange
+        AuthRequest request = new AuthRequest("john@example.com", "wrongPassword");
+
+        when(authenticationManager.authenticate(any(UsernamePasswordAuthenticationToken.class)))
+                .thenThrow(new BadCredentialsException("Bad credentials"));
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Bad credentials");
+
+        verify(jwtUtil, never()).generateToken(anyString(), anyList());
+        verify(jwtUtil, never()).generateRefreshToken(any());
+    }
+
+    @Test
+    void refreshTokenReturnsNewAccessToken() {
+        // Arrange
+        String refreshToken = "valid-refresh-token";
+
+        when(jwtUtil.getSubject(refreshToken)).thenReturn("john@example.com");
+        when(memberRepository.findByEmail("john@example.com")).thenReturn(Optional.of(memberEntity));
+        when(memberMapper.memberEntityToMemberDTO(memberEntity)).thenReturn(memberDTO);
+        when(jwtUtil.generateToken("john@example.com", List.of("ROLE_USER"))).thenReturn("new-access-token");
+
+        // Act
+        RefreshResponse response = authService.refreshToken(refreshToken);
+
+        // Assert
+        assertThat(response.accessToken()).isEqualTo("new-access-token");
+    }
+
+    @Test
+    void refreshTokenThrowsWhenUserNotFound() {
+        // Arrange
+        String refreshToken = "valid-refresh-token";
+
+        when(jwtUtil.getSubject(refreshToken)).thenReturn("unknown@example.com");
+        when(memberRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.refreshToken(refreshToken))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("User not found");
+
+        verify(jwtUtil, never()).generateToken(anyString(), anyList());
+    }
+
+    @Test
+    void refreshTokenThrowsWhenSubjectDoesNotMatchUsername() {
+        // Arrange
+        String refreshToken = "tampered-token";
+        MemberEntity differentMember = new MemberEntity();
+        differentMember.setEmail("other@example.com");
+
+        when(jwtUtil.getSubject(refreshToken)).thenReturn("john@example.com");
+        when(memberRepository.findByEmail("john@example.com")).thenReturn(Optional.of(differentMember));
+
+        // Act & Assert
+        assertThatThrownBy(() -> authService.refreshToken(refreshToken))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Invalid token");
+
+        verify(jwtUtil, never()).generateToken(anyString(), anyList());
+    }
+}

--- a/fit-track/src/test/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtilTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtilTest.java
@@ -1,0 +1,172 @@
+package com.robinsonir.fittrack.security.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.SecretKey;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtTokenUtilTest {
+
+    private JwtTokenUtil jwtTokenUtil;
+
+    private static final String SECRET_KEY = "this-is-a-test-secret-key-that-is-long-enough-for-hmac-sha256";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jwtTokenUtil = new JwtTokenUtil();
+        Field secretKeyField = JwtTokenUtil.class.getDeclaredField("secretKey");
+        secretKeyField.setAccessible(true);
+        secretKeyField.set(jwtTokenUtil, SECRET_KEY);
+    }
+
+    @Test
+    void generateTokenReturnsNonNullToken() {
+        String token = jwtTokenUtil.generateToken("user@example.com", List.of("ROLE_USER"));
+
+        assertThat(token).isNotNull().isNotBlank();
+    }
+
+    @Test
+    void getSubjectReturnsCorrectSubject() {
+        String email = "user@example.com";
+        String token = jwtTokenUtil.generateToken(email, List.of("ROLE_USER"));
+
+        String subject = jwtTokenUtil.getSubject(token);
+
+        assertThat(subject).isEqualTo(email);
+    }
+
+    @Test
+    void generateTokenIncludesScopesInClaims() {
+        String token = jwtTokenUtil.generateToken("user@example.com", List.of("ROLE_USER", "ROLE_ADMIN"));
+
+        SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+        var claims = Jwts.parser()
+                .requireIssuer("fittrack")
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        assertThat(claims.get("scopes")).isEqualTo(List.of("ROLE_USER", "ROLE_ADMIN"));
+        assertThat(claims.getIssuer()).isEqualTo("fittrack");
+    }
+
+    @Test
+    void generateTokenExpiresInFifteenMinutes() {
+        Instant before = Instant.now().plus(14, ChronoUnit.MINUTES);
+        String token = jwtTokenUtil.generateToken("user@example.com", List.of("ROLE_USER"));
+        Instant after = Instant.now().plus(16, ChronoUnit.MINUTES);
+
+        SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+        Date expiration = Jwts.parser()
+                .requireIssuer("fittrack")
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration();
+
+        assertThat(expiration.toInstant()).isAfter(before);
+        assertThat(expiration.toInstant()).isBefore(after);
+    }
+
+    @Test
+    void generateRefreshTokenReturnsNonNullToken() {
+        String token = jwtTokenUtil.generateRefreshToken("user@example.com");
+
+        assertThat(token).isNotNull().isNotBlank();
+    }
+
+    @Test
+    void generateRefreshTokenHasCorrectSubject() {
+        String email = "user@example.com";
+        String token = jwtTokenUtil.generateRefreshToken(email);
+
+        String subject = jwtTokenUtil.getSubject(token);
+
+        assertThat(subject).isEqualTo(email);
+    }
+
+    @Test
+    void generateRefreshTokenExpiresInThirtyDays() {
+        Instant before = Instant.now().plus(29, ChronoUnit.DAYS);
+        String token = jwtTokenUtil.generateRefreshToken("user@example.com");
+        Instant after = Instant.now().plus(31, ChronoUnit.DAYS);
+
+        SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+        Date expiration = Jwts.parser()
+                .requireIssuer("fittrack")
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration();
+
+        assertThat(expiration.toInstant()).isAfter(before);
+        assertThat(expiration.toInstant()).isBefore(after);
+    }
+
+    @Test
+    void isTokenValidReturnsTrueForValidToken() {
+        String email = "user@example.com";
+        String token = jwtTokenUtil.generateToken(email, List.of("ROLE_USER"));
+
+        assertThat(jwtTokenUtil.isTokenValid(token, email)).isTrue();
+    }
+
+    @Test
+    void isTokenValidReturnsFalseForWrongUsername() {
+        String token = jwtTokenUtil.generateToken("user@example.com", List.of("ROLE_USER"));
+
+        assertThat(jwtTokenUtil.isTokenValid(token, "other@example.com")).isFalse();
+    }
+
+    @Test
+    void isTokenExpiredReturnsFalseForFreshToken() {
+        String token = jwtTokenUtil.generateToken("user@example.com", List.of("ROLE_USER"));
+
+        assertThat(jwtTokenUtil.isTokenExpired(token)).isFalse();
+    }
+
+    @Test
+    void isTokenExpiredThrowsForExpiredToken() {
+        SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+        String expiredToken = Jwts.builder()
+                .subject("user@example.com")
+                .issuer("fittrack")
+                .issuedAt(Date.from(Instant.now().minus(2, ChronoUnit.HOURS)))
+                .expiration(Date.from(Instant.now().minus(1, ChronoUnit.HOURS)))
+                .signWith(key)
+                .compact();
+
+        assertThatThrownBy(() -> jwtTokenUtil.isTokenExpired(expiredToken))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+
+    @Test
+    void isTokenValidThrowsForExpiredToken() {
+        SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+        String expiredToken = Jwts.builder()
+                .subject("user@example.com")
+                .issuer("fittrack")
+                .issuedAt(Date.from(Instant.now().minus(2, ChronoUnit.HOURS)))
+                .expiration(Date.from(Instant.now().minus(1, ChronoUnit.HOURS)))
+                .signWith(key)
+                .compact();
+
+        assertThatThrownBy(() -> jwtTokenUtil.isTokenValid(expiredToken, "user@example.com"))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+}

--- a/fit-track/src/test/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtilTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/security/jwt/JwtTokenUtilTest.java
@@ -6,8 +6,9 @@ import io.jsonwebtoken.security.Keys;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.test.util.ReflectionTestUtils;
+
 import javax.crypto.SecretKey;
-import java.lang.reflect.Field;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -23,11 +24,9 @@ class JwtTokenUtilTest {
     private static final String SECRET_KEY = "this-is-a-test-secret-key-that-is-long-enough-for-hmac-sha256";
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         jwtTokenUtil = new JwtTokenUtil();
-        Field secretKeyField = JwtTokenUtil.class.getDeclaredField("secretKey");
-        secretKeyField.setAccessible(true);
-        secretKeyField.set(jwtTokenUtil, SECRET_KEY);
+        ReflectionTestUtils.setField(jwtTokenUtil, "secretKey", SECRET_KEY);
     }
 
     @Test


### PR DESCRIPTION
# FTRACK-9: Implement refresh token authentication

## Description

- Implemented refresh token flow to improve authentication security by replacing the single long-lived JWT with short-lived access tokens (15 min) and long-lived refresh tokens (30 days).

## Changes

- **Backend:**
  - Added `generateRefreshToken()` method to `JwtTokenUtil` with 30-day expiration
  - Reduced access token expiration from 24 hours to 15 minutes
  - Added `/api/v1/auth/refresh` endpoint with `RefreshRequest`/`RefreshResponse` records
  - Updated `AuthService` with `refreshToken()` method that validates and issues new access tokens
  - Updated `AuthResponse` to return both `accessToken` and `refreshToken` (renamed from `jwtToken`)
  - Updated `SecurityFilterChainConfig` to permit the refresh endpoint without authentication
  - Updated `JWTAuthenticationFilter` to continue filter chain on expired tokens instead of throwing
  - Updated `MemberController` registration to return both tokens
- **Frontend:**
  - Added Axios request interceptor that detects expired access tokens and silently refreshes them
  - Implemented `refreshAccessToken()` with deduplication via shared promise
  - Updated `AuthContext` to store/clear refresh tokens in localStorage
  - Updated `ProtectedRoute` to use `member` and `loading` state instead of `isMemberAuthenticated()`
- **Tests:**
  - Added `JwtTokenUtilTest` (12 tests) covering token generation, expiration, validation, and claims
  - Added `AuthServiceTest` (5 tests) covering login, refresh, and error scenarios
- **API Collection:**
  - Added Bruno `Refresh Token` request and updated environment variables

## Testing

- **Old behavior:** Single JWT token with 24-hour expiration; expired tokens returned 401 requiring re-login
- **New behavior:** Short-lived access tokens (15 min) are silently refreshed using a 30-day refresh token; users stay authenticated longer without re-entering credentials
- All 12 `JwtTokenUtilTest` and 5 `AuthServiceTest` tests pass

## Screenshots

- N/A (backend/auth flow changes)

## Additional Comments

- The refresh endpoint validates the refresh token's subject against the database before issuing a new access token

# Checklist

- [x] All tests are passing
- [x] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly