### PR TITLE
Feats(ui): compose TopBar with routing and avatar dropdown

### DIFF
--- a/fit-track-ui/react/.storybook/preview.tsx
+++ b/fit-track-ui/react/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import type { Preview, Decorator } from "@storybook/react";
 import { withThemeByDataAttribute } from "@storybook/addon-themes";
 import React from "react";
+import { ThemeProvider } from "../src/context/theme-context";
 
 // IMPORTANT: This loads your design tokens, Tailwind utilities, and @font-face
 // declarations into every story. Without this import, your tokens won't apply
@@ -77,6 +78,16 @@ const preview: Preview = {
       defaultTheme: "light",
       attributeName: "data-theme",
     }),
+
+    // ThemeProvider — makes useTheme() available in every story.
+    // withThemeByDataAttribute (above) sets [data-theme] on the DOM, but
+    // it does not provide ThemeContext. Components that call useTheme()
+    // would throw without this wrapper.
+    (Story) => (
+        <ThemeProvider>
+          <Story />
+        </ThemeProvider>
+    ),
 
     // Wrap every story in a container that applies your design system's
     // baseline typography and spacing. This ensures stories render in the

--- a/fit-track-ui/react/src/components/layout/TopBar/AvatarMenu.tsx
+++ b/fit-track-ui/react/src/components/layout/TopBar/AvatarMenu.tsx
@@ -1,0 +1,184 @@
+import { useAuth } from "../../../context/AuthContext";
+import { useTheme } from "../../../context/theme-context";
+import { useNavigate } from "react-router-dom";
+import { AvatarButton } from "../../ui/AvatarButton/AvatarButton";
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+} from "../../ui/DropdownMenu/DropdownMenu.tsx";
+
+/* ============================================================================
+ * AvatarMenu
+ * ----------------------------------------------------------------------------
+ *
+ * The avatar dropdown menu for the TopBar's right region. Composes the
+ * AvatarButton primitive (as the trigger) with DropdownMenu primitive
+ * (as the contents). Reads from useAuth and useTheme to populate.
+ *
+ * Menu contents (in order):
+ *   1. User label (name + email, non-interactive)
+ *   2. Profile link → /profile
+ *   3. Separator
+ *   4. Theme label
+ *   5. Light / Dark / System theme items (each shows ◉ when active)
+ *   6. Separator
+ *   7. Settings link → /settings
+ *   8. Separator
+ *   9. Sign out (destructive)
+ *
+ * Profile image is intentionally not shown — MemberDTO.profileImageId is
+ * an ID, not a URL. When the backend exposes an image-serving endpoint
+ * (likely during Settings work in FTRACK-26), this component should be
+ * updated to pass imageUrl to AvatarButton. For now, initials only.
+ *
+ * Storybook caveat:
+ *   This component requires AuthProvider + ThemeProvider + Router in context.
+ *   See TopBar.stories.tsx for the mock decorators that satisfy these.
+ * ============================================================================ */
+
+type ThemeOption = "light" | "dark" | "system";
+
+const THEME_OPTIONS: { value: ThemeOption; label: string  }[] = [
+    { value: "light", label: "Light" },
+    { value: "dark", label: "Dark" },
+    { value: "system", label: "System" },
+];
+
+export function AvatarMenu() {
+    const { member, logOut } = useAuth();
+    const { theme, setTheme } = useTheme();
+    const navigate = useNavigate();
+
+    // Defensive fallback: if member is undefined (shouldn't happen inside a
+    // protected route, but TypeScript doesn't know that), show a placeholder.
+    // Better to render something than crash
+    const displayName = member?.name ?? "Member";
+    const displayEmail = member?.email ?? "";
+
+    const handleProfileClick = () => {
+        navigate("/profile");
+    };
+
+    const handleSettingsClick = () => {
+        navigate("/settings");
+    };
+
+    const handleThemeSelect = (value: ThemeOption) => {
+        setTheme(value);
+    };
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <AvatarButton name={displayName} />
+            </DropdownMenuTrigger>
+
+            <DropdownMenuContent>
+                {/* User identity header: non-interactive, just name + email */}
+                <div
+                    style={{
+                        padding: "var(--spacing-8) var(--spacing-12) var(--spacing-12)",
+                        borderBottom: "1px solid var(--color-linen-border)",
+                        marginBottom: "var(--spacing-4)",
+                    }}
+                >
+                    <div
+                        style={{
+                            fontFamily: "var(--font-aeonikpro)",
+                            fontSize: "14px",
+                            fontWeight: 500,
+                            color: "var(--color-charcoal-ink)",
+                            lineHeight: 1.3,
+                            marginBottom: "2px"
+                        }}
+                    >
+                        {displayName}
+                    </div>
+                    {displayEmail && (
+                        <div
+                            style={{
+                                fontFamily: "var(--font-aeonikpro)",
+                                fontSize: "12px",
+                                color: "var(--color-pewter-mute)",
+                                lineHeight: 1.3,
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                            }}
+                        >
+                            {displayEmail}
+                        </div>
+                    )}
+                </div>
+
+                {/* Profile link */}
+                <DropdownMenuItem onSelect={handleProfileClick}>Profile</DropdownMenuItem>
+
+                <DropdownMenuSeparator />
+
+                {/* Theme submenu: three explicit items with active indicator */}
+                <DropdownMenuLabel>Theme</DropdownMenuLabel>
+                {THEME_OPTIONS.map((option) => (
+                    <DropdownMenuItem
+                        key={option.value}
+                        onSelect={() => handleThemeSelect(option.value)}
+                    >
+                        <ThemeActiveIndicator active={theme === option.value} />
+                        <span>{option.label}</span>
+                    </DropdownMenuItem>
+                ))}
+
+                <DropdownMenuSeparator />
+
+                {/* Settings link */}
+                <DropdownMenuItem onSelect={handleSettingsClick}>Settings</DropdownMenuItem>
+
+                <DropdownMenuSeparator />
+
+                {/* Sign out: destructive, separated from non-destructive actions */}
+                <DropdownMenuItem destructive onSelect={logOut}>
+                    Sign out
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}
+
+/* ----------------------------------------------------------------------------
+ * ThemeActiveIndicator
+ * ----------------------------------------------------------------------------
+ * A small filled / hollow circle on the left side of theme items. Shows
+ * which theme is currently selected. The circle is 8px diameter, sits in
+ * a 16px gutter so the labels align consistently regardless of active state.
+ * ---------------------------------------------------------------------------- */
+
+function ThemeActiveIndicator({ active }: { active: boolean }) {
+    return (
+        <span
+            aria-hidden="true"
+            style={{
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                width: "16px",
+                height: "16px",
+                flexShrink: 0,
+            }}
+        >
+            <span
+                style={{
+                    width: "8px",
+                    height: "8px",
+                    borderRadius: "9999px",
+                    backgroundColor: active ? "var(--color-indigo-signal)": "transparent",
+                    border: active ? "none" : "1.5px solid var(--color-pewter-border)",
+                    transition: "background 80ms ease, border-color 80ms ease",
+                }}
+            />
+        </span>
+    );
+}

--- a/fit-track-ui/react/src/components/layout/TopBar/TopBar.stories.tsx
+++ b/fit-track-ui/react/src/components/layout/TopBar/TopBar.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { TopBar } from "./TopBar";
+import { MockAuthProvider } from "./storybook/MockAuthProvider";
+
+/* ============================================================================
+ * Storybook metadata
+ * ----------------------------------------------------------------------------
+ * The TopBar requires three React contexts to render: Router (for navigation
+ * + active state), AuthProvider (for member data + logOut), and ThemeProvider
+ * (which is already mounted globally in preview.tsx).
+ *
+ * We provide Router via MemoryRouter (so navigation works without changing
+ * the browser URL) and Auth via a MockAuthProvider that returns a stub
+ * member without making real API calls.
+ * ============================================================================ */
+
+const meta: Meta<typeof TopBar> = {
+    title: "Layout / TopBar",
+    component: TopBar,
+    parameters: {
+        layout: "fullscreen",
+        backgrounds: { default: "Paper Canvas" },
+        docs: {
+            description: {
+                component:
+                    "The application shell's primary chrome. Composes Wordmark (left), three pill nav items (center), and Primary CTA + Avatar menu (right). Pill active state is route-driven. Avatar menu reads from useAuth and useTheme to populate sign-out, theme toggle, and profile/settings navigation.",
+            },
+        },
+    },
+    decorators: [
+        (Story, context) => (
+            <MockAuthProvider>
+                <MemoryRouter
+                    initialEntries={[context.parameters.initialRoute ?? "/dashboard"]}
+                >
+                    <Routes>
+                        {/* Catch-all route so navigation works inside stories without
+                rendering anything below the TopBar. The empty element is
+                intentional — we're just verifying the TopBar itself. */}
+                        <Route path="*" element={<Story />} />
+                    </Routes>
+                </MemoryRouter>
+            </MockAuthProvider>
+        ),
+    ],
+    argTypes: {
+        onAddWorkout: {
+            action: "Add workout clicked",
+        },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TopBar>;
+
+/* ----------------------------------------------------------------------------
+ * Default — TopBar on the Dashboard route
+ * ---------------------------------------------------------------------------- */
+
+export const Default: Story = {
+    args: {},
+};
+
+/* ----------------------------------------------------------------------------
+ * ActivitiesActive — Activities pill highlighted
+ * ----------------------------------------------------------------------------
+ * Demonstrates route-driven active state. Same TopBar, different active
+ * pill, because the initial route is /activities.
+ * ---------------------------------------------------------------------------- */
+
+export const ActivitiesActive: Story = {
+    args: {},
+    parameters: {
+        initialRoute: "/activities",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * ProfileActive — Profile pill highlighted
+ * ---------------------------------------------------------------------------- */
+
+export const PlanActive: Story = {
+    args: {},
+    parameters: {
+        initialRoute: "/plan",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * NoActiveRoute — none of the pills are active
+ * ----------------------------------------------------------------------------
+ * Edge case: user is on a route that isn't represented in the nav (e.g.,
+ * /settings, /404, /onboarding). All pills should render as inactive —
+ * no pill should accidentally highlight.
+ * ---------------------------------------------------------------------------- */
+
+export const NoActiveRoute: Story = {
+    args: {},
+    parameters: {
+        initialRoute: "/settings",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * WithDashboardContent — TopBar above mock page content
+ * ----------------------------------------------------------------------------
+ * Shows the visual relationship between the TopBar chrome and the page
+ * content below. Useful for verifying the hairline border feels right
+ * (not too heavy, not invisible).
+ * ---------------------------------------------------------------------------- */
+
+export const WithDashboardContent: Story = {
+    args: {},
+    render: (args) => (
+        <div style={{ minHeight: "100vh" }}>
+            <TopBar {...args} />
+            <main
+                style={{
+                    maxWidth: "1360px",
+                    margin: "0 auto",
+                    padding: "var(--spacing-48) var(--layout-page-padding-x)",
+                }}
+            >
+                <h1
+                    style={{
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "var(--text-heading)",
+                        fontWeight: 500,
+                        letterSpacing: "var(--tracking-heading)",
+                        color: "var(--color-charcoal-ink)",
+                        margin: 0,
+                        marginBottom: "var(--spacing-16)",
+                    }}
+                >
+                    Good morning, Long
+                </h1>
+                <p
+                    style={{
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "var(--text-body)",
+                        color: "var(--color-smoke-ink)",
+                        margin: 0,
+                        maxWidth: "60ch",
+                    }}
+                >
+                    Tuesday is usually Pull Day 2. Real Dashboard content would render
+                    here, but for this story it&apos;s just text — we&apos;re verifying the TopBar
+                    chrome reads correctly against page content below.
+                </p>
+            </main>
+        </div>
+    ),
+};

--- a/fit-track-ui/react/src/components/layout/TopBar/TopBar.tsx
+++ b/fit-track-ui/react/src/components/layout/TopBar/TopBar.tsx
@@ -1,0 +1,142 @@
+import { useLocation, useNavigate } from "react-router-dom";
+import { Wordmark } from "../../ui/WordMark/Wordmark";
+import { PillNavigationItem } from "../../ui/PillNavigationItem/PillNavigationItem";
+import { ActionButton } from "../../ui/ActionButton/ActionButton";
+import { AvatarMenu } from "./AvatarMenu";
+
+/* ============================================================================
+ * TopBar
+ * ----------------------------------------------------------------------------
+ * The application shell's primary chrome. Three regions:
+ *
+ *   - Left:   Wordmark
+ *   - Center: Pill navigation (Dashboard, Activities, Profile)
+ *   - Right:  Primary CTA (Add workout) + Avatar menu
+ *
+ * Pill nav active state is route-driven via React Router's useLocation.
+ * Clicking a pill navigates to its route.
+ *
+ * The "Add workout" CTA fires an onAddWorkout callback rather than owning
+ * modal state. The parent (Layout in FTRACK-19) owns the WorkoutModal and
+ * handles open/close. This keeps TopBar a pure chrome component — it
+ * doesn't know about workout modals or any other feature concerns.
+ *
+ * Avatar menu is composed via the separate AvatarMenu component, which
+ * handles theme switching, profile/settings navigation, and sign-out
+ * via existing useAuth and useTheme hooks.
+ *
+ * Used by:
+ *   - Root layout (Layout component in pages/layout.tsx, after FTRACK-19)
+ *
+ * Design tokens consumed:
+ *   - --color-paper-canvas    (background)
+ *   - --color-linen-border    (hairline border bottom)
+ *   - --layout-topbar-height  (72px)
+ *   - --layout-page-padding-x (40px)
+ *
+ * Not yet mounted in production — this component exists in the codebase
+ * for FTRACK-18 verification but is still rendered in Storybook only.
+ * FTRACK-19 will replace the existing sidebar with this component.
+ * ============================================================================ */
+
+interface TopBarProps {
+    /** Fires when the user clicks the "Add workout" primary CTA. The parent
+     * is expected to open the 'WorkoutModal' (or equivalent flow). TopBar
+     * doesn't own modal state. */
+    onAddWorkout: () => void;
+}
+
+interface NavItem {
+    label: string;
+    path: string;
+}
+
+const NAV_ITEMS: NavItem[] = [
+    { label: "Dashboard", path: "/dashboard" },
+    { label: "Activities", path: "/activities" },
+    { label: "Plan", path: "/plan" },
+];
+
+export function TopBar({ onAddWorkout }: TopBarProps) {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    /* Determine which nav item is active based on the current pathname.
+     *  Uses startsWith() rather than exact equality so that nested routes
+     * (e.g., /activities/:id) still highlight the parent pill. */
+    const isActive = (path: string): boolean => {
+        return location.pathname === path || location.pathname.startsWith(`${path}/`);
+    };
+
+    return (
+        <header
+            style={{
+                height: "var(--layout-topbar-height)",
+                padding: "0 var(--layout-page-padding-x)",
+                display: "grid",
+                gridTemplateColumns: "1fr auto 1fr",
+                alignItems: "center",
+                backgroundColor: "var(--color-paper-canvas)",
+                borderBottom: "1px solid var(--color-linen-border)",
+            }}
+        >
+            {/* Left region: Wordmark */}
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "flex-start",
+                }}
+            >
+                <button
+                    type="button"
+                    onClick={() => navigate("/dashboard")}
+                    style={{
+                        background: "transparent",
+                        border: "none",
+                        padding: "0",
+                        cursor: "pointer",
+                    }}
+                    aria-label="FitTrack — Go to dashboard"
+                >
+                    <Wordmark />
+                </button>
+            </div>
+
+            {/* Center region — Pill navigation */}
+            <nav
+                aria-label="Primary navigation"
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "var(--spacing-4)",
+                }}
+            >
+                {NAV_ITEMS.map((item) => (
+                    <PillNavigationItem
+                        key={item.path}
+                        active={isActive(item.path)}
+                        onClick={() => navigate(item.path)}
+                    >
+                        {item.label}
+                    </PillNavigationItem>
+                ))}
+            </nav>
+
+            {/* Right region — Primary CTA + Avatar menu */}
+            <div
+                style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "flex-end",
+                    gap: "var(--spacing-16)",
+                }}
+            >
+                <ActionButton variant="primary" onClick={onAddWorkout}>
+                    Add workout
+                </ActionButton>
+                <AvatarMenu />
+            </div>
+        </header>
+    );
+}

--- a/fit-track-ui/react/src/components/layout/TopBar/storybook/MockAuthProvider.tsx
+++ b/fit-track-ui/react/src/components/layout/TopBar/storybook/MockAuthProvider.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from "react";
+import { AuthContext } from "../../../../context/AuthContext";
+
+/* ============================================================================
+ * MockAuthProvider — Storybook-only
+ * ----------------------------------------------------------------------------
+ * Provides a stub AuthContext value for Storybook stories. The TopBar (and
+ * any of its children) calls useAuth(), which reads from AuthContext. By
+ * wrapping stories in this provider, useAuth() returns the mock data
+ * instead of crashing.
+ *
+ * Prerequisite: AuthContext must be exported from src/context/AuthContext.tsx
+ * (one-line change to add `export` to the createContext line). The mock
+ * value matches the real AuthContextType shape.
+ * ============================================================================ */
+
+const mockMember = {
+    id: 1,
+    name: "Long Tang",
+    email: "long.tang@example.com",
+    username: "longtang",
+    profileImageId: undefined,
+};
+
+const mockValue = {
+    member: mockMember,
+    loading: false,
+    login: async () => {
+        console.log("[Storybook] login called — no-op");
+    },
+    register: async () => {
+        console.log("[Storybook] register called — no-op");
+    },
+    logOut: () => {
+        console.log("[Storybook] logOut called — would clear tokens and redirect to /login");
+    },
+    refreshMember: async () => {
+        console.log("[Storybook] refreshMember called — no-op");
+    },
+};
+
+export function MockAuthProvider({ children }: { children: ReactNode }) {
+    return (
+        <AuthContext.Provider value={mockValue as never}>
+            {children}
+        </AuthContext.Provider>
+    );
+}

--- a/fit-track-ui/react/src/components/ui/AvatarButton/AvatarButton.tsx
+++ b/fit-track-ui/react/src/components/ui/AvatarButton/AvatarButton.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import { forwardRef, type ButtonHTMLAttributes } from "react";
 import * as Avatar from "@radix-ui/react-avatar";
 
 /* ============================================================================
@@ -28,12 +28,9 @@ import * as Avatar from "@radix-ui/react-avatar";
  *     mouse click)
  * ============================================================================ */
 
-interface AvatarButtonProps {
+interface AvatarButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
     name: string;
     imageUrl?: string;
-    onClick?: () => void;
-    /** Optional className for layout positioning. */
-    className?: string;
 }
 
 /* Helper: convert "Long Tang" → "LT". Falls back gracefully for single-word
@@ -65,16 +62,16 @@ function getInitials(name: string): string {
 }
 
 export const AvatarButton = forwardRef<HTMLButtonElement, AvatarButtonProps>(
-    function AvatarButton({ name, imageUrl, onClick, className }, ref) {
+    function AvatarButton({ name, imageUrl, className, ...rest }, ref) {
         const initials = getInitials(name);
 
         return (
             <button
                 ref={ref}
                 type="button"
-                onClick={onClick}
                 aria-label={`${name} menu`}
                 className={className}
+                {...rest}
                 style={{
                 // Reset default button chrome
                     border: "none",

--- a/fit-track-ui/react/src/context/AuthContext.tsx
+++ b/fit-track-ui/react/src/context/AuthContext.tsx
@@ -14,7 +14,7 @@ type AuthContextType = {
 };
 
 
-const AuthContext = createContext<AuthContextType | null>(null);
+export const AuthContext = createContext<AuthContextType | null>(null);
 
 const AuthProvider = ({children}: { children: any }) => {
     const {me: fetchMe, registerMember} = useMemo(() => getMemberApi(), []);


### PR DESCRIPTION
<!-- Thank you for using the Fit Track pull request template. -->

# FTRACK-18: Compose TopBar with routing and avatar dropdown

## Description

Composes the TopBar primitives into a real `<TopBar />` component and wires it to React Router, `useAuth`, and `useTheme`. Adds an avatar dropdown menu with the four canonical items (Profile, Theme toggle, Settings, Sign out) and route-driven active state for the three primary pills (Dashboard, Activities, Plan).

This PR also includes the FTRACK-17 primitive deliverables (Wordmark, AvatarButton, PillNavigationItem, ActionButton, DropdownMenu) since they were built and verified ahead of this composition step.

The TopBar exists in the codebase but is not yet mounted in the application shell. The existing sidebar is still active. Cutover to the new shell happens in FTRACK-19.

## Changes

**New primitives** (`src/components/ui/`)
- `Wordmark/` — "FitTrack" in AeonikPro, no icon mark in v1
- `AvatarButton/` — circular 40px avatar with initials fallback, built on `@radix-ui/react-avatar`, `forwardRef`-aware so it can serve as a Radix dropdown trigger via `asChild`
- `PillNavigationItem/` — three-state pill (inactive, active, hover) with `aria-current="page"` when active
- `ActionButton/` — primary/secondary/ghost variants in one component, `forwardRef`-aware, full disabled handling
- `DropdownMenu/` — compound API (`Root`, `Trigger`, `Content`, `Item`, `Separator`, `Label`) built on `@radix-ui/react-dropdown-menu`; destructive variant for sign-out-style items; portal-rendered with subtle elevation

**TopBar composition** (`src/components/layout/TopBar/`)
- `TopBar.tsx` — three-region grid layout (1fr auto 1fr) with route-driven active pill state via `useLocation`. Wordmark click navigates to `/dashboard`. Primary CTA fires an `onAddWorkout` callback (parent owns modal state).
- `AvatarMenu.tsx` — avatar dropdown with user identity header (name + email), Profile link, three-item theme toggle (Light / Dark / System with active indicator dot), Settings link, destructive Sign out. Reads from `useAuth` and `useTheme`.
- `TopBar.stories.tsx` — five Storybook stories: Default, ActivitiesActive, PlanActive, NoActiveRoute, WithDashboardContent.

**Nav pill structure**
- Three pills: Dashboard (daily check-in), Activities (history log), Plan (routines + exercises).
- Profile removed from pill nav; now reachable only via the avatar dropdown header. Standard SaaS chrome convention; removes the double-access redundancy.
- `/plan` is a stub route at this stage; the destination page is scoped in FTRACK-34.

**Supporting changes**
- `src/context/AuthContext.tsx` — added `export` to `AuthContext` so Storybook can mock the context value without invoking the real provider's API effects.
- `src/components/layout/TopBar/storybook/MockAuthProvider.tsx` — Storybook-only stub provider that supplies a mock `MemberDTO` without making API calls. Co-located with the component it supports.

**Dependencies added**
- `@radix-ui/react-dropdown-menu` — accessible dropdown primitive (focus management, keyboard nav, click-outside dismissal, ARIA)
- `@radix-ui/react-avatar` — image-with-initials-fallback behavior

## Testing

**Old behavior:** No TopBar component existed. The application chrome was the existing sidebar (`src/components/features/sidebar/Sidebar.tsx`), still mounted via `pages/layout.tsx`.

**New behavior:** The `<TopBar />` component exists in the codebase and is verifiable end-to-end in Storybook. The sidebar continues to be the production chrome — no user-facing change ships from this PR. Cutover happens in FTRACK-19.

**Verified in Storybook** (`Layout → TopBar`):
- Default story renders Dashboard pill active
- ActivitiesActive renders Activities pill active
- PlanActive renders Plan pill active
- NoActiveRoute (initial route `/settings`) renders no active pill
- WithDashboardContent shows the TopBar above mock page content with correct hairline border
- Clicking pills updates the active state via `MemoryRouter`
- Add workout button fires the action (visible in Storybook Actions panel)
- Avatar dropdown opens with all sections: user header (Long Tang + email), Profile link, Theme submenu with active indicator on the current theme, Settings link, Sign out in Brick Danger
- Theme toggle updates the active indicator correctly when clicked
- Keyboard focus rings render on the wordmark button, pills, action button, and avatar; pressing Enter on the avatar opens the dropdown

## Screenshots

*[Add: Default story (Dashboard active), avatar dropdown open with theme indicator, hover state on a pill]*

## Additional Comments

- The "Add workout" CTA's persistent placement in the TopBar is being tracked for post-Dashboard re-evaluation in FTRACK-33 — designer raised concerns about it fighting the "quiet at a glance" North Star. Shipping as-is per the locked FTRACK-16 spec; revisit after FTRACK-21 (Dashboard composition) lands.
- Profile images are deferred — `MemberDTO.profileImageId` is an ID, not a URL. Backend touch-point flagged for when the image-serving endpoint exists. `AvatarMenu` passes only `name` to `AvatarButton` for now; the initials fallback handles all current cases.
- The `MockAuthProvider` is co-located under `src/components/layout/TopBar/storybook/` rather than in a shared mocks directory. The intent is that Storybook-only dependencies live next to the component they support so they can't accidentally be imported into production code.

# Checklist

- [ ] All tests are passing
- [ ] Documentation updated (if needed)
- [ ] No TODOs left
- [ ] Code is formatted properly