### PR TITLE
Docs(storybook): build Dashboard primitives

### DIFF
--- a/fit-track-ui/react/src/components/ui/ActivityRow/ActivityRow.stories.tsx
+++ b/fit-track-ui/react/src/components/ui/ActivityRow/ActivityRow.stories.tsx
@@ -1,0 +1,241 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ActivityRow } from "./ActivityRow";
+import { SectionTitle } from "../SectionTitle/SectionTitle";
+
+const meta: Meta<typeof ActivityRow> = {
+    title: "Components / Dashboard / ActivityRow",
+    component: ActivityRow,
+    parameters: {
+        layout: "padded",
+        docs: {
+            description: {
+                component:
+                    "Full-row-clickable activity entry. Two variants: `compact` for the Dashboard's Recent Activity list (single line, no highlight); `full` for the Activities page (two lines, highlight shown). The type dot color is derived from the workout type name — strength types glow saffron, cardio types go moss-positive.",
+            },
+        },
+    },
+    tags: ["autodocs"],
+    argTypes: {
+        type: {
+            control: "text",
+            description: "Workout type label (e.g. \"Push\", \"Cardio\")",
+        },
+        timestamp: {
+            control: "text",
+            description: "Pre-formatted date/time string",
+        },
+        duration: {
+            control: "text",
+            description: "Pre-formatted duration string",
+        },
+        highlight: {
+            control: "text",
+            description: "Optional highlight text (PR, notable event)",
+        },
+        variant: {
+            control: "radio",
+            options: ["compact", "full"],
+            description: "compact = Dashboard single-line · full = Activities two-line",
+        },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ActivityRow>;
+
+/* ----------------------------------------------------------------------------
+ * CompactDefault — typical Dashboard row
+ * ---------------------------------------------------------------------------- */
+
+export const CompactDefault: Story = {
+    args: {
+        type: "Push",
+        timestamp: "Mon, Jun 9",
+        duration: "48 min",
+        variant: "compact",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * CompactNoHighlight — no highlight prop in compact (not rendered anyway)
+ * Shows that compact gracefully ignores the highlight prop.
+ * ---------------------------------------------------------------------------- */
+
+export const CompactNoHighlight: Story = {
+    args: {
+        type: "Cardio",
+        timestamp: "Sat, Jun 7",
+        duration: "32 min",
+        highlight: "7.2 km", // ignored in compact
+        variant: "compact",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * FullDefault — Activities page row, no highlight
+ * ---------------------------------------------------------------------------- */
+
+export const FullDefault: Story = {
+    args: {
+        type: "Pull",
+        timestamp: "Tue, Jun 10",
+        duration: "55 min",
+        variant: "full",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * FullWithHighlight — Activities page row with PR notation
+ * ---------------------------------------------------------------------------- */
+
+export const FullWithHighlight: Story = {
+    args: {
+        type: "Legs",
+        timestamp: "Mon, Jun 9",
+        duration: "1h 12min",
+        highlight: "PR: 225 lbs squat",
+        variant: "full",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * DotColors — all three dot color categories side by side (compact)
+ * ---------------------------------------------------------------------------- */
+
+export const DotColors: Story = {
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: "400px" }}>
+            <ActivityRow type="Push" timestamp="Mon, Jun 9" duration="48 min" variant="compact" />
+            <ActivityRow type="Run" timestamp="Sun, Jun 8" duration="32 min" variant="compact" />
+            <ActivityRow type="Mobility" timestamp="Sat, Jun 7" duration="20 min" variant="compact" />
+        </div>
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * HoverState — wrapped in a list to make hover easy to test
+ * ---------------------------------------------------------------------------- */
+
+export const HoverState: Story = {
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: "400px" }}>
+            <ActivityRow
+                type="Push"
+                timestamp="Mon, Jun 9"
+                duration="48 min"
+                variant="compact"
+                onClick={() => console.log("Push clicked")}
+            />
+            <ActivityRow
+                type="Pull"
+                timestamp="Sun, Jun 8"
+                duration="52 min"
+                variant="compact"
+                onClick={() => console.log("Pull clicked")}
+            />
+            <ActivityRow
+                type="Legs"
+                timestamp="Fri, Jun 6"
+                duration="1h 12min"
+                variant="compact"
+                onClick={() => console.log("Legs clicked")}
+            />
+        </div>
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * ListOfRows — compact list as it appears on Dashboard
+ * ---------------------------------------------------------------------------- */
+
+export const ListOfRows: Story = {
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: "480px" }}>
+            <ActivityRow type="Push" timestamp="Mon, Jun 9" duration="48 min" variant="compact" />
+            <ActivityRow type="Cardio" timestamp="Sun, Jun 8" duration="32 min" variant="compact" />
+            <ActivityRow type="Pull" timestamp="Fri, Jun 6" duration="52 min" variant="compact" />
+            <ActivityRow type="Legs" timestamp="Wed, Jun 4" duration="1h 12min" variant="compact" />
+            <ActivityRow type="Upper Body" timestamp="Mon, Jun 2" duration="44 min" variant="compact" />
+        </div>
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * FullList — full variant as it appears on Activities page
+ * ---------------------------------------------------------------------------- */
+
+export const FullList: Story = {
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: "600px" }}>
+            <ActivityRow
+                type="Push"
+                timestamp="Mon, Jun 9"
+                duration="48 min"
+                highlight="PR: 225 lbs bench"
+                variant="full"
+            />
+            <ActivityRow
+                type="Cardio"
+                timestamp="Sun, Jun 8"
+                duration="32 min"
+                highlight="7.2 km"
+                variant="full"
+            />
+            <ActivityRow
+                type="Pull"
+                timestamp="Fri, Jun 6"
+                duration="52 min"
+                variant="full"
+            />
+            <ActivityRow
+                type="Legs"
+                timestamp="Wed, Jun 4"
+                duration="1h 12min"
+                highlight="PR: 315 lbs deadlift"
+                variant="full"
+            />
+            <ActivityRow
+                type="Mobility"
+                timestamp="Mon, Jun 2"
+                duration="20 min"
+                variant="full"
+            />
+        </div>
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * InContext — SectionTitle + compact list (Dashboard-style)
+ * ---------------------------------------------------------------------------- */
+
+export const InContext: Story = {
+    render: () => (
+        <div style={{ maxWidth: "480px" }}>
+            <SectionTitle>Recent activity</SectionTitle>
+            <div style={{ display: "flex", flexDirection: "column" }}>
+                <ActivityRow
+                    type="Push"
+                    timestamp="Mon, Jun 9"
+                    duration="48 min"
+                    variant="compact"
+                    onClick={() => console.log("Navigate to Push detail")}
+                />
+                <ActivityRow
+                    type="Cardio"
+                    timestamp="Sun, Jun 8"
+                    duration="32 min"
+                    variant="compact"
+                    onClick={() => console.log("Navigate to Cardio detail")}
+                />
+                <ActivityRow
+                    type="Pull"
+                    timestamp="Fri, Jun 6"
+                    duration="52 min"
+                    variant="compact"
+                    onClick={() => console.log("Navigate to Pull detail")}
+                />
+            </div>
+        </div>
+    ),
+};

--- a/fit-track-ui/react/src/components/ui/ActivityRow/ActivityRow.tsx
+++ b/fit-track-ui/react/src/components/ui/ActivityRow/ActivityRow.tsx
@@ -1,0 +1,283 @@
+/* ============================================================================
+ * ActivityRow
+ * ----------------------------------------------------------------------------
+ * A full-row-clickable activity entry used in two contexts:
+ *
+ *   compact  — Dashboard "Recent Activity" list. Single line: type on left,
+ *              duration + timestamp on right. No highlight.
+ *
+ *   full     — Activities page. Two lines: type + optional highlight on the
+ *              left column; timestamp + duration on the right column.
+ *
+ * Rendered as a <button> so the entire row is keyboard-accessible. The caller
+ * is responsible for navigation (push to workout detail, etc.).
+ *
+ * Type dot color is derived from the workout type name:
+ *   strength keywords (Push/Pull/Legs/Upper/Lower/Full/Strength) → saffron
+ *   cardio keywords (Run/Cardio/Bike/Swim/Walk/HIIT)             → moss-positive
+ *   everything else                                              → pewter-mute
+ *
+ * Highlight parsing: if highlight starts with "PR:" the prefix renders in
+ * --color-saffron-mark (500 weight); the rest renders in --color-charcoal-ink.
+ * All other highlights render in --color-charcoal-ink at 400 weight.
+ * A hidden placeholder line is always reserved in full variant so row heights
+ * are consistent whether or not a highlight is present.
+ *
+ * Used by:
+ *   - Dashboard ("Recent Activity" section, compact variant)
+ *   - Activities page (full variant)
+ *
+ * Design tokens consumed:
+ *   - --color-paper-canvas      (base background — matches page)
+ *   - --color-vellum-surface    (hover background)
+ *   - --color-linen-border      (row bottom separator)
+ *   - --color-charcoal-ink      (type + highlight text)
+ *   - --color-smoke-ink         (duration text)
+ *   - --color-pewter-mute       (timestamp, separator dot, default dot)
+ *   - --color-saffron-mark      (strength-type dot + "PR:" prefix)
+ *   - --color-moss-positive     (cardio-type dot)
+ *   - --color-indigo-press      (focus ring)
+ *   - --font-aeonikpro          (all text)
+ *   - --radius-rows             (hover background radius)
+ *   - --spacing-8               (compact vertical padding)
+ *   - --spacing-12              (full vertical padding)
+ *   - --spacing-4               (internal gaps)
+ *
+ * Accessibility:
+ *   - Full row is a <button> — keyboard activation via Enter/Space.
+ *   - aria-label: "{type} · {duration}{highlight ? ' · ' + highlight : ''}"
+ *   - Visible focus ring on keyboard focus only (mirrors PillNavigationItem).
+ * ============================================================================ */
+
+import { forwardRef, useState } from "react";
+import type { ButtonHTMLAttributes } from "react";
+
+type ActivityVariant = "compact" | "full";
+
+interface ActivityRowProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "type"> {
+    /** Workout type label (e.g., "Push", "Pull", "Legs", "Cardio"). */
+    type: string;
+    /** Pre-formatted timestamp string (e.g., "Mon, Jun 9" or "Today, 9:41 AM"). */
+    timestamp: string;
+    /** Pre-formatted duration string (e.g., "48 min", "1h 12min"). */
+    duration: string;
+    /** Optional highlight — personal record or notable event.
+     *  If it starts with "PR:" the prefix renders in saffron-mark. */
+    highlight?: string;
+    /** "compact" → single-line Dashboard row. "full" → two-line Activities row.
+     *  Defaults to "compact". */
+    variant?: ActivityVariant;
+}
+
+const STRENGTH_KEYWORDS = /push|pull|legs|upper|lower|full|strength|lift|squat|deadlift/i;
+const CARDIO_KEYWORDS = /run|cardio|bike|swim|walk|hike|hiit|row|cycle|elliptical/i;
+
+function dotColor(type: string): string {
+    if (STRENGTH_KEYWORDS.test(type)) return "var(--color-saffron-mark)";
+    if (CARDIO_KEYWORDS.test(type)) return "var(--color-moss-positive)";
+    return "var(--color-pewter-mute)";
+}
+
+function buildAriaLabel(type: string, duration: string, highlight?: string): string {
+    let label = `${type} · ${duration}`;
+    if (highlight) label += ` · ${highlight}`;
+    return label;
+}
+
+/* Render highlight text. "PR:" prefix gets saffron treatment; rest is charcoal. */
+function HighlightText({ text }: { text: string }) {
+    if (text.startsWith("PR:")) {
+        return (
+            <>
+                <span style={{ color: "var(--color-saffron-mark)", fontWeight: 500 }}>PR:</span>
+                <span style={{ color: "var(--color-charcoal-ink)" }}>{text.slice(3)}</span>
+            </>
+        );
+    }
+    return <span style={{ color: "var(--color-charcoal-ink)" }}>{text}</span>;
+}
+
+export const ActivityRow = forwardRef<HTMLButtonElement, ActivityRowProps>(
+    function ActivityRow(
+        { type, timestamp, duration, highlight, variant = "compact", className, ...rest },
+        ref,
+    ) {
+        const [hovered, setHovered] = useState(false);
+        const [focusVisible, setFocusVisible] = useState(false);
+
+        const paddingY = variant === "full" ? "var(--spacing-12)" : "var(--spacing-8)";
+
+        return (
+            // Wrapper carries the separator so the button's borderRadius is unobstructed.
+            <div
+                className={className}
+                style={{ borderBottom: "1px solid var(--color-linen-border)" }}
+            >
+                <button
+                    ref={ref}
+                    type="button"
+                    aria-label={buildAriaLabel(type, duration, highlight)}
+                    onMouseEnter={() => setHovered(true)}
+                    onMouseLeave={() => setHovered(false)}
+                    onFocus={(e) => {
+                        if (e.target.matches(":focus-visible")) setFocusVisible(true);
+                    }}
+                    onBlur={() => setFocusVisible(false)}
+                    style={{
+                    // Reset button chrome
+                        border: "none",
+                        cursor: "pointer",
+                        textAlign: "left",
+                        width: "100%",
+
+                        // Layout
+                        display: "flex",
+                        flexDirection: "row",
+                        alignItems: variant === "full" ? "flex-start" : "center",
+                        justifyContent: "space-between",
+                        padding: `${paddingY} var(--spacing-8)`,
+                        gap: "var(--spacing-16)",
+
+                        // Pill hover — borderRadius free because separator lives on wrapper
+                        backgroundColor: hovered ? "var(--color-vellum-surface)" : "transparent",
+                        borderRadius: "var(--radius-rows)",
+
+                        // Focus ring (keyboard only)
+                        outline: "none",
+                        boxShadow: focusVisible
+                            ? "0 0 0 2px var(--color-paper-canvas), 0 0 0 4px var(--color-indigo-press)"
+                            : "none",
+
+                        transition: "background-color 100ms ease",
+                    }}
+                    {...rest}
+                >
+                    {/* Left column */}
+                    <div
+                        style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: "var(--spacing-4)",
+                            minWidth: 0,
+                        }}
+                    >
+                        {/* Type row: dot + label */}
+                        <div
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "var(--spacing-8)",
+                            }}
+                        >
+                            <span
+                                aria-hidden="true"
+                                style={{
+                                    flexShrink: 0,
+                                    width: "7px",
+                                    height: "7px",
+                                    borderRadius: "9999px",
+                                    backgroundColor: dotColor(type),
+                                }}
+                            />
+                            <span
+                                style={{
+                                    fontFamily: "var(--font-aeonikpro)",
+                                    fontSize: "15px",
+                                    fontWeight: 500,
+                                    color: "var(--color-charcoal-ink)",
+                                    lineHeight: 1.3,
+                                    whiteSpace: "nowrap",
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                }}
+                            >
+                                {type}
+                            </span>
+                        </div>
+
+                        {/* Highlight line — full variant only.
+                        Always rendered (visible or hidden) to lock row height. */}
+                        {variant === "full" && (
+                            <span
+                                aria-hidden={!highlight || undefined}
+                                style={{
+                                    fontFamily: "var(--font-aeonikpro)",
+                                    fontSize: "13px",
+                                    fontWeight: 400,
+                                    lineHeight: 1.4,
+                                    paddingLeft: "15px", // aligns with type text (7px dot + 8px gap)
+                                    visibility: highlight ? "visible" : "hidden",
+                                }}
+                            >
+                                {highlight ? <HighlightText text={highlight} /> : "​"}
+                            </span>
+                        )}
+                    </div>
+
+                    {/* Right column */}
+                    {variant === "compact" ? (
+                    // Compact: duration (smoke-ink, 500) · timestamp (pewter-mute, 400)
+                        <span
+                            style={{
+                                flexShrink: 0,
+                                fontFamily: "var(--font-aeonikpro)",
+                                fontSize: "13px",
+                                lineHeight: 1.3,
+                                whiteSpace: "nowrap",
+                            }}
+                        >
+                            <span style={{ fontWeight: 500, color: "var(--color-smoke-ink)" }}>
+                                {duration}
+                            </span>
+                            <span
+                                aria-hidden="true"
+                                style={{ margin: "0 5px", color: "var(--color-pewter-mute)" }}
+                            >
+                            ·
+                            </span>
+                            <span style={{ fontWeight: 400, color: "var(--color-pewter-mute)" }}>
+                                {timestamp}
+                            </span>
+                        </span>
+                    ) : (
+                    // Full: timestamp (pewter-mute, 400) on top; duration (smoke-ink, 500) below
+                        <div
+                            style={{
+                                flexShrink: 0,
+                                display: "flex",
+                                flexDirection: "column",
+                                alignItems: "flex-end",
+                                gap: "var(--spacing-4)",
+                            }}
+                        >
+                            <span
+                                style={{
+                                    fontFamily: "var(--font-aeonikpro)",
+                                    fontSize: "13px",
+                                    fontWeight: 400,
+                                    color: "var(--color-pewter-mute)",
+                                    lineHeight: 1.3,
+                                    whiteSpace: "nowrap",
+                                }}
+                            >
+                                {timestamp}
+                            </span>
+                            <span
+                                style={{
+                                    fontFamily: "var(--font-aeonikpro)",
+                                    fontSize: "13px",
+                                    fontWeight: 500,
+                                    color: "var(--color-smoke-ink)",
+                                    lineHeight: 1.3,
+                                    whiteSpace: "nowrap",
+                                }}
+                            >
+                                {duration}
+                            </span>
+                        </div>
+                    )}
+                </button>
+            </div>
+        );
+    },
+);

--- a/fit-track-ui/react/src/components/ui/InsightCard/InsightCard.stories.tsx
+++ b/fit-track-ui/react/src/components/ui/InsightCard/InsightCard.stories.tsx
@@ -1,0 +1,125 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InsightCard } from "./InsightCard";
+import { SectionTitle } from "../SectionTitle/SectionTitle";
+
+const meta: Meta<typeof InsightCard> = {
+    title: "Components / Dashboard / InsightCard",
+    component: InsightCard,
+    parameters: {
+        layout: "padded",
+        docs: {
+            description: {
+                component:
+                    "Observation-only card for the Dashboard's Noticed section. Renders one sentence. No actions, no links — the companion voice observes, it does not prescribe. `body` is typed as `string` to enforce this at the API level.",
+            },
+        },
+    },
+    tags: ["autodocs"],
+    argTypes: {
+        body: {
+            control: "text",
+            description: "Observational sentence. Plain string — no rich content.",
+        },
+        eyebrow: {
+            control: "text",
+            description: "Optional monospace eyebrow label (e.g. \"NOTICED\")",
+        },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof InsightCard>;
+
+/* ----------------------------------------------------------------------------
+ * Default
+ * ---------------------------------------------------------------------------- */
+
+export const Default: Story = {
+    args: {
+        body: "You trained 3 times this week, up from 2 last week.",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * WithEyebrow — the intended full treatment
+ * ---------------------------------------------------------------------------- */
+
+export const WithEyebrow: Story = {
+    args: {
+        eyebrow: "Noticed",
+        body: "You trained 3 times this week, up from 2 last week.",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * LongBody — verify line-break handling
+ * ---------------------------------------------------------------------------- */
+
+export const LongBody: Story = {
+    args: {
+        eyebrow: "Noticed",
+        body: "Your average session duration has increased by 8 minutes over the past three weeks, which suggests your work capacity is growing without a corresponding drop in workout frequency.",
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ maxWidth: "480px" }}>
+                <Story />
+            </div>
+        ),
+    ],
+};
+
+/* ----------------------------------------------------------------------------
+ * CompanionVoiceExamples — three cards showing right vs. wrong copy
+ * The right kind: observational. The wrong kind: prescriptive.
+ * ---------------------------------------------------------------------------- */
+
+export const CompanionVoiceExamples: Story = {
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: "16px", maxWidth: "480px" }}>
+            {/* Good examples — observational, present-tense, no prescription */}
+            <InsightCard
+                eyebrow="Noticed"
+                body="You trained 3 times this week, up from 2 last week."
+            />
+            <InsightCard
+                eyebrow="Noticed"
+                body="Your push sessions have been averaging 48 minutes this month."
+            />
+            <InsightCard
+                eyebrow="Noticed"
+                body="Tuesday is your most consistent training day — you&apos;ve hit it 8 of the last 9 weeks."
+            />
+            {/*
+             * Companion voice rules for InsightCard copy:
+             *   ✓ Factual, present-tense, past-tense observation
+             *   ✓ References the user's own data
+             *   ✓ No imperative verbs ("try", "consider", "add", "reduce")
+             *   ✓ No editorial framing ("great job", "you need to", "you should")
+             *   ✗ Avoid: "Try adding a rest day this week."
+             *   ✗ Avoid: "You should consider reducing volume."
+             *   ✗ Avoid: "Great job hitting your target!"
+             */}
+        </div>
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * InContext — preceded by SectionTitle("Noticed")
+ * Verifies rhythm: SectionTitle 12px gap → InsightCard
+ * ---------------------------------------------------------------------------- */
+
+export const InContext: Story = {
+    render: () => (
+        <div style={{ maxWidth: "480px" }}>
+            {/* SectionTitle already labels the section — eyebrow omitted to avoid
+                reading "NOTICED" twice. Pass eyebrow only when InsightCard
+                appears without a parent SectionTitle. */}
+            <SectionTitle>Noticed</SectionTitle>
+            <InsightCard
+                body="You trained 3 times this week, up from 2 last week."
+            />
+        </div>
+    ),
+};

--- a/fit-track-ui/react/src/components/ui/InsightCard/InsightCard.tsx
+++ b/fit-track-ui/react/src/components/ui/InsightCard/InsightCard.tsx
@@ -1,0 +1,88 @@
+/* ============================================================================
+ * InsightCard
+ * ----------------------------------------------------------------------------
+ * A quiet, observation-only card for the Dashboard's "Noticed" section.
+ * Renders a single sentence. No action affordances — no buttons, no links,
+ * no chevrons. The absence of interactivity is a deliberate design constraint:
+ * the moment an action appears, the card becomes a prompt, which violates the
+ * companion voice. InsightCard observes; it does not prescribe.
+ *
+ * The `body` prop is typed as `string` (not ReactNode) to enforce this
+ * constraint at the type level. Callers cannot sneak interactive content in.
+ *
+ * Used by:
+ *   - Dashboard ("Noticed" section)
+ *
+ * Design tokens consumed:
+ *   - --color-vellum-surface   (card background)
+ *   - --color-linen-border     (1px card border)
+ *   - --color-charcoal-ink     (body text)
+ *   - --color-pewter-mute      (eyebrow text)
+ *   - --font-aeonikpro         (body typeface)
+ *   - --font-mono              (eyebrow typeface)
+ *   - --tracking-small         (eyebrow letter-spacing)
+ *   - --radius-cards           (12px border-radius)
+ *   - --spacing-24             (card padding)
+ *   - --spacing-8              (gap between eyebrow and body)
+ *
+ * Accessibility:
+ *   - Not interactive — no role, no tabIndex, no keyboard handling.
+ *   - cursor: default to signal non-interactivity.
+ * ============================================================================ */
+
+interface InsightCardProps {
+    /** The observational sentence. Plain string only — no rich content.
+     *  Write in companion voice: factual, present-tense, no prescription.
+     *  Good: "You trained 3 times this week, up from 2 last week."
+     *  Avoid: "Try adding a rest day this week." */
+    body: string;
+    /** Optional monospace eyebrow label above the body (e.g. "NOTICED"). */
+    eyebrow?: string;
+    /** className passthrough for layout positioning. */
+    className?: string;
+}
+
+export function InsightCard({ body, eyebrow, className }: InsightCardProps) {
+    return (
+        <div
+            className={className}
+            style={{
+                padding: "var(--spacing-24)",
+                backgroundColor: "var(--color-vellum-surface)",
+                border: "1px solid var(--color-linen-border)",
+                borderRadius: "var(--radius-cards)",
+                cursor: "default",
+            }}
+        >
+            {eyebrow && (
+                <span
+                    style={{
+                        display: "block",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: "11px",
+                        fontWeight: 500,
+                        color: "var(--color-pewter-mute)",
+                        letterSpacing: "var(--tracking-small)",
+                        textTransform: "uppercase",
+                        lineHeight: 1,
+                        marginBottom: "var(--spacing-12)",
+                    }}
+                >
+                    {eyebrow}
+                </span>
+            )}
+            <p
+                style={{
+                    margin: 0,
+                    fontFamily: "var(--font-aeonikpro)",
+                    fontSize: "16px",
+                    fontWeight: 400,
+                    color: "var(--color-charcoal-ink)",
+                    lineHeight: 1.5,
+                }}
+            >
+                {body}
+            </p>
+        </div>
+    );
+}

--- a/fit-track-ui/react/src/components/ui/MetricCard/MetricCard.stories.tsx
+++ b/fit-track-ui/react/src/components/ui/MetricCard/MetricCard.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MetricCard } from "./MetricCard";
+import { SectionTitle } from "../SectionTitle/SectionTitle";
+
+const meta: Meta<typeof MetricCard> = {
+    title: "Components / Dashboard / MetricCard",
+    component: MetricCard,
+    parameters: {
+        layout: "padded",
+        docs: {
+            description: {
+                component:
+                    "Stat tile for the Dashboard's Quick Stats row. Value dominates at 36px — glanceable in under a second. Optional secondary text supports a +/- prefix convention: '+' renders in moss-positive, '-' in rust-negative (prefix only, not the full string). Loading state renders pulsing skeleton blocks.",
+            },
+        },
+    },
+    tags: ["autodocs"],
+    argTypes: {
+        label: {
+            control: "text",
+            description: "Metric label — rendered uppercase, muted",
+        },
+        value: {
+            control: "text",
+            description: "Primary value — caller formats it (commas, units, decimals)",
+        },
+        secondary: {
+            control: "text",
+            description: "Secondary line — prefix '+' = green, '-' = rust",
+        },
+        loading: {
+            control: "boolean",
+            description: "Renders skeleton placeholders",
+        },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof MetricCard>;
+
+/* ----------------------------------------------------------------------------
+ * Default
+ * ---------------------------------------------------------------------------- */
+
+export const Default: Story = {
+    args: {
+        label: "Sessions this week",
+        value: 3,
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * WithSecondary — target context
+ * ---------------------------------------------------------------------------- */
+
+export const WithSecondary: Story = {
+    args: {
+        label: "Sessions this week",
+        value: 3,
+        secondary: "/ 4 target",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * WithPositiveDelta — "+" prefix in moss-positive
+ * ---------------------------------------------------------------------------- */
+
+export const WithPositiveDelta: Story = {
+    args: {
+        label: "Sessions this week",
+        value: 3,
+        secondary: "+1 from last week",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * WithNegativeDelta — "-" prefix in rust-negative
+ * ---------------------------------------------------------------------------- */
+
+export const WithNegativeDelta: Story = {
+    args: {
+        label: "Sessions this week",
+        value: 2,
+        secondary: "-1 from last week",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * ZeroState — value=0 renders plainly, no special treatment
+ * ---------------------------------------------------------------------------- */
+
+export const ZeroState: Story = {
+    args: {
+        label: "Sessions this week",
+        value: 0,
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * LoadingState — skeleton placeholders
+ * ---------------------------------------------------------------------------- */
+
+export const LoadingState: Story = {
+    args: {
+        label: "Sessions this week",
+        value: "",
+        loading: true,
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * ThreeColumn — the actual Dashboard usage pattern
+ * ---------------------------------------------------------------------------- */
+
+export const ThreeColumn: Story = {
+    render: () => (
+        <div
+            style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 1fr)",
+                gap: "16px",
+                maxWidth: "720px",
+            }}
+        >
+            <MetricCard label="Sessions this week" value={3} secondary="+1 from last week" />
+            <MetricCard label="Total volume" value="12,450 lbs" secondary="+8% from last week" />
+            <MetricCard label="Avg duration" value="52 min" secondary="/ 60 min target" />
+        </div>
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * LargeValue — verify long values don't break layout
+ * ---------------------------------------------------------------------------- */
+
+export const LargeValue: Story = {
+    render: () => (
+        <div
+            style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(3, 1fr)",
+                gap: "16px",
+                maxWidth: "720px",
+            }}
+        >
+            <MetricCard label="Total volume" value={12500} />
+            <MetricCard label="Longest session" value="2:45:30" />
+            <MetricCard label="Best lift" value="125 lbs" />
+        </div>
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * InContext — SectionTitle("This week") + three MetricCards in a row
+ * ---------------------------------------------------------------------------- */
+
+export const InContext: Story = {
+    render: () => (
+        <div style={{ maxWidth: "720px" }}>
+            <SectionTitle>This week</SectionTitle>
+            <div
+                style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(3, 1fr)",
+                    gap: "16px",
+                }}
+            >
+                <MetricCard label="Sessions" value={3} secondary="+1 from last week" />
+                <MetricCard label="Volume" value="12,450 lbs" secondary="+8% from last week" />
+                <MetricCard label="Avg duration" value="52 min" secondary="/ 60 min target" />
+            </div>
+        </div>
+    ),
+};

--- a/fit-track-ui/react/src/components/ui/MetricCard/MetricCard.tsx
+++ b/fit-track-ui/react/src/components/ui/MetricCard/MetricCard.tsx
@@ -1,0 +1,177 @@
+/* ============================================================================
+ * MetricCard
+ * ----------------------------------------------------------------------------
+ * Stat tile for the Dashboard's Quick Stats row. Typography hierarchy is the
+ * primary design challenge: value dominates at 36px, label and secondary
+ * recede. A user should register the number in under one second of looking.
+ *
+ * The `secondary` prop supports a "+/-" prefix convention: if secondary starts
+ * with "+" the prefix renders in --color-moss-positive; if it starts with "-"
+ * the prefix renders in --color-rust-negative. Only the prefix is colored —
+ * the rest of the text stays in --color-smoke-ink.
+ *
+ * The `loading` prop renders three skeleton blocks at label/value/secondary
+ * positions. The pulse animation is defined via a <style> tag injected once
+ * — no external CSS file required, consistent with the inline-styles pattern.
+ *
+ * Used by:
+ *   - Dashboard (Quick Stats row, three cards in a grid)
+ *
+ * Design tokens consumed:
+ *   - --color-paper-canvas     (card background)
+ *   - --color-linen-border     (1px card border)
+ *   - --color-charcoal-ink     (value text)
+ *   - --color-smoke-ink        (secondary text)
+ *   - --color-pewter-mute      (label text)
+ *   - --color-ash-inset        (skeleton background)
+ *   - --color-moss-positive    (positive delta prefix)
+ *   - --color-rust-negative    (negative delta prefix)
+ *   - --font-aeonikpro         (all text)
+ *   - --tracking-small         (label letter-spacing)
+ *   - --radius-cards           (12px border-radius)
+ *   - --spacing-24             (card padding)
+ *   - --spacing-8              (label→value gap)
+ *   - --spacing-4              (value→secondary gap)
+ *
+ * Accessibility:
+ *   - Not interactive — no role, no tabIndex.
+ *   - Loading state uses aria-busy="true" and aria-label for screen readers.
+ * ============================================================================ */
+
+interface MetricCardProps {
+    /** The metric label (e.g., "Sessions this week"). Rendered uppercase, muted. */
+    label: string;
+    /** The primary value. Caller is responsible for formatting (commas, units, decimals). */
+    value: string | number;
+    /** Optional secondary text below the value — target ("/ 4 target") or delta ("+1 from last week").
+     *  If it starts with "+" the prefix renders green; "-" renders rust. */
+    secondary?: string;
+    /** Renders skeleton placeholders instead of value/secondary. */
+    loading?: boolean;
+    /** className passthrough for layout positioning. */
+    className?: string;
+}
+
+/* Parse secondary text into a prefix (colored) and remainder (default color).
+ * Returns null prefix when no +/- prefix is present. */
+function parseSecondary(text: string): { prefix: string | null; rest: string } {
+    if (text.startsWith("+") || text.startsWith("-")) {
+        return { prefix: text[0], rest: text.slice(1) };
+    }
+    return { prefix: null, rest: text };
+}
+
+function prefixColor(prefix: string): string {
+    if (prefix === "+") return "var(--color-moss-positive)";
+    if (prefix === "-") return "var(--color-rust-negative)";
+    return "var(--color-smoke-ink)";
+}
+
+/* Skeleton block — a muted rectangle that pulses to signal loading. */
+function Skeleton({ width, height }: { width: string; height: string }) {
+    return (
+        <div
+            aria-hidden="true"
+            style={{
+                width,
+                height,
+                backgroundColor: "var(--color-ash-inset)",
+                borderRadius: "4px",
+                animation: "metric-card-pulse 1.4s ease-in-out infinite",
+            }}
+        />
+    );
+}
+
+/* Injected once per page render — defines the pulse keyframes without needing
+ * an external CSS file. Using a unique animation name to avoid collisions. */
+const PULSE_STYLE = `
+@keyframes metric-card-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
+}
+`;
+
+export function MetricCard({ label, value, secondary, loading = false, className }: MetricCardProps) {
+    return (
+        <>
+            <style>{PULSE_STYLE}</style>
+            <div
+                className={className}
+                aria-busy={loading || undefined}
+                aria-label={loading ? `${label}, loading` : undefined}
+                style={{
+                    padding: "var(--spacing-24)",
+                    backgroundColor: "var(--color-paper-canvas)",
+                    border: "1px solid var(--color-linen-border)",
+                    borderRadius: "var(--radius-cards)",
+                    display: "flex",
+                    flexDirection: "column",
+                }}
+            >
+                {/* Label */}
+                <span
+                    style={{
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "13px",
+                        fontWeight: 500,
+                        color: "var(--color-pewter-mute)",
+                        letterSpacing: "var(--tracking-small)",
+                        textTransform: "uppercase",
+                        lineHeight: 1,
+                        marginBottom: "var(--spacing-8)",
+                    }}
+                >
+                    {label}
+                </span>
+
+                {loading ? (
+                    <div style={{ display: "flex", flexDirection: "column", gap: "var(--spacing-4)" }}>
+                        <Skeleton width="60%" height="36px" />
+                        <Skeleton width="40%" height="16px" />
+                    </div>
+                ) : (
+                    <>
+                        {/* Value */}
+                        <span
+                            style={{
+                                fontFamily: "var(--font-aeonikpro)",
+                                fontSize: "36px",
+                                fontWeight: 500,
+                                color: "var(--color-charcoal-ink)",
+                                lineHeight: 1,
+                                marginBottom: secondary ? "var(--spacing-4)" : 0,
+                                fontVariantNumeric: "tabular-nums",
+                            }}
+                        >
+                            {value}
+                        </span>
+
+                        {/* Secondary */}
+                        {secondary && (() => {
+                            const { prefix, rest } = parseSecondary(secondary);
+                            return (
+                                <span
+                                    style={{
+                                        fontFamily: "var(--font-aeonikpro)",
+                                        fontSize: "13px",
+                                        fontWeight: 400,
+                                        color: "var(--color-smoke-ink)",
+                                        lineHeight: 1.4,
+                                    }}
+                                >
+                                    {prefix && (
+                                        <span style={{ color: prefixColor(prefix) }}>
+                                            {prefix}
+                                        </span>
+                                    )}
+                                    {rest}
+                                </span>
+                            );
+                        })()}
+                    </>
+                )}
+            </div>
+        </>
+    );
+}

--- a/fit-track-ui/react/src/components/ui/PageHeader/PageHeader.stories.tsx
+++ b/fit-track-ui/react/src/components/ui/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PageHeader } from "./PageHeader";
+import { ActionButton } from "../ActionButton/ActionButton";
+import { SectionTitle } from "../SectionTitle/SectionTitle";
+
+const meta: Meta<typeof PageHeader> = {
+    title: "Components / Dashboard / PageHeader",
+    component: PageHeader,
+    parameters: {
+        layout: "padded",
+        docs: {
+            description: {
+                component:
+                    "Personal greeting at the top of the Dashboard. Greeting + name on the first line, date below. Large but soft — grounded, not announce-y. Parent is responsible for computing the greeting and date strings.",
+            },
+        },
+    },
+    tags: ["autodocs"],
+    argTypes: {
+        greeting: {
+            control: "text",
+            description: "Greeting prefix (e.g. \"Good morning\")",
+        },
+        name: {
+            control: "text",
+            description: "User's first name",
+        },
+        date: {
+            control: "text",
+            description: "Pre-formatted date string",
+        },
+        action: {
+            control: false,
+            description: "Optional right-side action element",
+        },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PageHeader>;
+
+/* ----------------------------------------------------------------------------
+ * Default
+ * ---------------------------------------------------------------------------- */
+
+export const Default: Story = {
+    args: {
+        greeting: "Good morning",
+        name: "Long",
+        date: "Tuesday, June 11",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * AllGreetings — morning / afternoon / evening side by side
+ * ---------------------------------------------------------------------------- */
+
+export const AllGreetings: Story = {
+    render: () => (
+        <div style={{ display: "flex", flexDirection: "column", gap: "32px" }}>
+            <PageHeader greeting="Good morning" name="Long" date="Tuesday, June 11" />
+            <PageHeader greeting="Good afternoon" name="Long" date="Tuesday, June 11" />
+            <PageHeader greeting="Good evening" name="Long" date="Tuesday, June 11" />
+        </div>
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * WithAction — right-side ActionButton
+ * ---------------------------------------------------------------------------- */
+
+export const WithAction: Story = {
+    args: {
+        greeting: "Good morning",
+        name: "Long",
+        date: "Tuesday, June 11",
+    },
+    render: (args) => (
+        <PageHeader
+            {...args}
+            action={
+                <ActionButton variant="primary" onClick={() => console.log("Add workout")}>
+                    Add workout
+                </ActionButton>
+            }
+        />
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * LongName — verify layout doesn't break
+ * ---------------------------------------------------------------------------- */
+
+export const LongName: Story = {
+    args: {
+        greeting: "Good morning",
+        name: "Maximilian",
+        date: "Tuesday, June 11",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * InContext — PageHeader followed by SectionTitle + content placeholder
+ * Verifies the 32px bottom-margin flows correctly into the next section.
+ * ---------------------------------------------------------------------------- */
+
+export const InContext: Story = {
+    args: {
+        greeting: "Good morning",
+        name: "Long",
+        date: "Tuesday, June 11",
+    },
+    render: (args) => (
+        <div style={{ maxWidth: "720px" }}>
+            <PageHeader {...args} />
+            <SectionTitle>This week</SectionTitle>
+            <div
+                style={{
+                    height: "80px",
+                    backgroundColor: "var(--color-vellum-surface)",
+                    borderRadius: "var(--radius-cards)",
+                    border: "1px solid var(--color-linen-border)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontFamily: "var(--font-aeonikpro)",
+                    fontSize: "13px",
+                    color: "var(--color-pewter-mute)",
+                }}
+            >
+                Content follows here
+            </div>
+        </div>
+    ),
+};

--- a/fit-track-ui/react/src/components/ui/PageHeader/PageHeader.tsx
+++ b/fit-track-ui/react/src/components/ui/PageHeader/PageHeader.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from "react";
+
+/* ============================================================================
+ * PageHeader
+ * ----------------------------------------------------------------------------
+ * The personal greeting at the top of the Dashboard. Renders a greeting +
+ * name on the first line and a date on the second. Large but soft — personal
+ * and grounded rather than announce-y.
+ *
+ * The parent is responsible for computing the greeting string based on the
+ * time of day and the date string based on user preference. PageHeader
+ * renders whatever it receives — no date logic lives here.
+ *
+ * Used by:
+ *   - Dashboard (top of page, above all sections)
+ *
+ * Design tokens consumed:
+ *   - --color-charcoal-ink     (greeting text)
+ *   - --color-smoke-ink        (date text)
+ *   - --font-aeonikpro         (both lines)
+ *   - --tracking-heading       (greeting letter-spacing)
+ *   - --spacing-4              (gap between greeting and date)
+ *   - --spacing-32             (bottom margin before first section)
+ *
+ * Accessibility:
+ *   - Greeting renders as <h1> — it is the page's primary heading.
+ *   - Date renders as <p>.
+ *   - Action slot (if used) should be a button or link for keyboard access.
+ * ============================================================================ */
+
+interface PageHeaderProps {
+    /** The greeting text. Typically "Good morning", "Good afternoon", "Good evening". Parent computes based on time of day. */
+    greeting: string;
+    /** The user's first name. Appended to the greeting: "{greeting}, {name}". */
+    name: string;
+    /** The current date, pre-formatted by the parent (e.g., "Tuesday, June 11"). */
+    date: string;
+    /** Optional action element on the right side of the greeting row (e.g., a primary CTA). */
+    action?: ReactNode;
+    /** className passthrough for layout positioning. */
+    className?: string;
+}
+
+export function PageHeader({ greeting, name, date, action, className }: PageHeaderProps) {
+    return (
+        <div
+            className={className}
+            style={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-between",
+                alignItems: "flex-start",
+                marginBottom: "var(--spacing-32)",
+            }}
+        >
+            {/* Left: greeting + date stacked */}
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "var(--spacing-4)",
+                }}
+            >
+                <h1
+                    style={{
+                        margin: 0,
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "28px",
+                        fontWeight: 500,
+                        color: "var(--color-charcoal-ink)",
+                        letterSpacing: "var(--tracking-heading)",
+                        lineHeight: 1.1,
+                    }}
+                >
+                    {greeting}, {name}
+                </h1>
+                <p
+                    style={{
+                        margin: 0,
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "14px",
+                        fontWeight: 400,
+                        color: "var(--color-smoke-ink)",
+                        lineHeight: 1.4,
+                    }}
+                >
+                    {date}
+                </p>
+            </div>
+
+            {/* Right: optional action */}
+            {action && (
+                <div style={{ flexShrink: 0, paddingTop: "2px" }}>
+                    {action}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/fit-track-ui/react/src/components/ui/SectionTitle/SectionTitle.stories.tsx
+++ b/fit-track-ui/react/src/components/ui/SectionTitle/SectionTitle.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SectionTitle } from "./SectionTitle";
+
+const meta: Meta<typeof SectionTitle> = {
+    title: "Components / Dashboard / SectionTitle",
+    component: SectionTitle,
+    parameters: {
+        layout: "padded",
+        docs: {
+            description: {
+                component:
+                    "Quiet label above each Dashboard section. Establishes vertical rhythm with a 12px bottom margin. Small, muted, uppercase — a reference point, not a heading. Optional eyebrow (monospace) and right-side action slot.",
+            },
+        },
+    },
+    tags: ["autodocs"],
+    argTypes: {
+        children: {
+            control: "text",
+            description: "Section label text",
+        },
+        eyebrow: {
+            control: "text",
+            description: "Optional monospace eyebrow above the title",
+        },
+        action: {
+            control: false,
+            description: "Optional right-side action (ReactNode)",
+        },
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SectionTitle>;
+
+/* ----------------------------------------------------------------------------
+ * Default — bare title, no action, no eyebrow
+ * ---------------------------------------------------------------------------- */
+
+export const Default: Story = {
+    args: {
+        children: "This week",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * WithAction — title + right-aligned "View all" link
+ * ---------------------------------------------------------------------------- */
+
+export const WithAction: Story = {
+    args: {
+        children: "Recent activity",
+    },
+    render: (args) => (
+        <SectionTitle
+            {...args}
+            action={
+                <button
+                    type="button"
+                    style={{
+                        background: "none",
+                        border: "none",
+                        padding: 0,
+                        cursor: "pointer",
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "13px",
+                        fontWeight: 400,
+                        color: "var(--color-indigo-signal)",
+                        letterSpacing: "var(--tracking-small)",
+                    }}
+                >
+                    View all
+                </button>
+            }
+        />
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * WithEyebrow — title with a small monospace eyebrow above
+ * ---------------------------------------------------------------------------- */
+
+export const WithEyebrow: Story = {
+    args: {
+        children: "Volume",
+        eyebrow: "Weekly",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * FullExample — title + eyebrow + action together
+ * ---------------------------------------------------------------------------- */
+
+export const FullExample: Story = {
+    args: {
+        children: "This week",
+        eyebrow: "Progress",
+    },
+    render: (args) => (
+        <SectionTitle
+            {...args}
+            action={
+                <button
+                    type="button"
+                    style={{
+                        background: "none",
+                        border: "none",
+                        padding: 0,
+                        cursor: "pointer",
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "13px",
+                        fontWeight: 400,
+                        color: "var(--color-indigo-signal)",
+                        letterSpacing: "var(--tracking-small)",
+                    }}
+                >
+                    View all
+                </button>
+            }
+        />
+    ),
+};
+
+/* ----------------------------------------------------------------------------
+ * InContext — SectionTitle followed by a mock content region
+ * Verifies the 12px bottom-margin rhythm before content begins.
+ * ---------------------------------------------------------------------------- */
+
+export const InContext: Story = {
+    args: {
+        children: "This week",
+    },
+    render: (args) => (
+        <div style={{ maxWidth: "480px" }}>
+            <SectionTitle {...args} />
+            <div
+                style={{
+                    height: "80px",
+                    backgroundColor: "var(--color-vellum-surface)",
+                    borderRadius: "var(--radius-cards)",
+                    border: "1px solid var(--color-linen-border)",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontFamily: "var(--font-aeonikpro)",
+                    fontSize: "13px",
+                    color: "var(--color-pewter-mute)",
+                }}
+            >
+                Content follows here
+            </div>
+        </div>
+    ),
+};

--- a/fit-track-ui/react/src/components/ui/SectionTitle/SectionTitle.tsx
+++ b/fit-track-ui/react/src/components/ui/SectionTitle/SectionTitle.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+
+/* ============================================================================
+ * SectionTitle
+ * ----------------------------------------------------------------------------
+ * Quiet label that sits above each Dashboard section ("This week",
+ * "Recent activity", "Noticed"). Establishes vertical rhythm — the 12px
+ * bottom margin is the consistent gap between a section label and the
+ * content that follows it.
+ *
+ * The companion-voice design rule: section titles are reference points, not
+ * headings. They should recede visually so content dominates. Hence: small
+ * size, muted color, uppercase with tracking.
+ *
+ * Used by:
+ *   - Dashboard (above Quick Stats, Recent Activity, Insights sections)
+ *
+ * Design tokens consumed:
+ *   - --color-pewter-mute      (title + eyebrow color)
+ *   - --font-aeonikpro         (title typeface)
+ *   - --font-mono              (eyebrow typeface)
+ *   - --tracking-small         (uppercase letter-spacing)
+ *   - --spacing-4              (gap between eyebrow and title)
+ *   - --spacing-12             (bottom margin before content)
+ *
+ * Accessibility:
+ *   - Renders as a <div> with aria-label passthrough via className.
+ *   - Not a heading element — sections are not document-outline sections.
+ *   - Action slot (if used) should be a button or link for keyboard access.
+ * ============================================================================ */
+
+interface SectionTitleProps {
+    /** The section label text. */
+    children: ReactNode;
+    /** Optional right-side action. Typically a "View all" ghost link or small button. */
+    action?: ReactNode;
+    /** Optional eyebrow text rendered above the title in monospace. Used for extra-low-emphasis labels. */
+    eyebrow?: string;
+    /** className passthrough for layout positioning. */
+    className?: string;
+}
+
+export function SectionTitle({ children, action, eyebrow, className }: SectionTitleProps) {
+    return (
+        <div
+            className={className}
+            style={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "space-between",
+                alignItems: "baseline",
+                marginBottom: "var(--spacing-12)",
+            }}
+        >
+            {/* Left: optional eyebrow stacked above title */}
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "var(--spacing-4)",
+                }}
+            >
+                {eyebrow && (
+                    <span
+                        style={{
+                            fontFamily: "var(--font-mono)",
+                            fontSize: "11px",
+                            fontWeight: 500,
+                            color: "var(--color-pewter-mute)",
+                            letterSpacing: "var(--tracking-small)",
+                            textTransform: "uppercase",
+                            lineHeight: 1,
+                        }}
+                    >
+                        {eyebrow}
+                    </span>
+                )}
+                <span
+                    style={{
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "14px",
+                        fontWeight: 500,
+                        color: "var(--color-pewter-mute)",
+                        letterSpacing: "var(--tracking-small)",
+                        textTransform: "uppercase",
+                        lineHeight: 1,
+                    }}
+                >
+                    {children}
+                </span>
+            </div>
+
+            {/* Right: optional action (pushed to far edge via space-between) */}
+            {action && (
+                <div style={{ flexShrink: 0 }}>
+                    {action}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/fit-track-ui/react/src/design-system/tokens.css
+++ b/fit-track-ui/react/src/design-system/tokens.css
@@ -84,8 +84,8 @@
     --color-saffron-wash: #FEF9C3;
 
     /* COLORS — Semantic */
-    --color-moss-success: #4F7A3E;
-    --color-rust-warning: #C2410C;
+    --color-moss-positive: #4F7A3E;
+    --color-rust-negative: #C2410C;
     --color-brick-danger: #991B1B;
 
     /* FONT FAMILIES */
@@ -155,6 +155,7 @@
     --radius-badges: 4px;
     --radius-inputs: 8px;
     --radius-buttons: 8px;
+    --radius-rows: 8px;
     --radius-cards: 12px;
     --radius-modals: 16px;
     --radius-hero-cards: 20px;

--- a/fit-track-ui/react/src/design-system/tokens/Colors.stories.tsx
+++ b/fit-track-ui/react/src/design-system/tokens/Colors.stories.tsx
@@ -367,13 +367,13 @@ export const AllColors: Story = {
                     <Swatch
                         name="Moss Success"
                         value="#4F7A3E"
-                        token="--color-moss-success"
+                        token="--color-moss-positive"
                         role="Semantic success — routine completion (workout saved, sync done)"
                     />
                     <Swatch
                         name="Rust Warning"
                         value="#C2410C"
-                        token="--color-rust-warning"
+                        token="--color-rust-negative"
                         role="Semantic warning — overload signals, deload prompts, recovery alerts"
                     />
                     <Swatch
@@ -548,13 +548,13 @@ export const Semantic: Story = {
                 <Swatch
                     name="Moss Success"
                     value="#4F7A3E"
-                    token="--color-moss-success"
+                    token="--color-moss-positive"
                     role="Workout saved, sync complete, routine confirmation"
                 />
                 <Swatch
                     name="Rust Warning"
                     value="#C2410C"
-                    token="--color-rust-warning"
+                    token="--color-rust-negative"
                     role="Overload signals, deload prompts, recovery alerts"
                 />
                 <Swatch

--- a/fit-track-ui/react/src/design-system/tokens/Surfaces.stories.tsx
+++ b/fit-track-ui/react/src/design-system/tokens/Surfaces.stories.tsx
@@ -419,7 +419,7 @@ export const ElevationRefusal: Story = {
                         style={{
                             fontFamily: "var(--font-mono)",
                             fontSize: "var(--text-mono-label)",
-                            color: "var(--color-moss-success)",
+                            color: "var(--color-moss-positive)",
                             fontVariantNumeric: "tabular-nums",
                             marginBottom: "var(--spacing-12)",
                             letterSpacing: "var(--tracking-small)",
@@ -475,7 +475,7 @@ export const ElevationRefusal: Story = {
                         style={{
                             fontFamily: "var(--font-mono)",
                             fontSize: "var(--text-mono-label)",
-                            color: "var(--color-rust-warning)",
+                            color: "var(--color-rust-negative)",
                             fontVariantNumeric: "tabular-nums",
                             marginBottom: "var(--spacing-12)",
                             letterSpacing: "var(--tracking-small)",


### PR DESCRIPTION
# FTRACK-35: Build Dashboard primitives in Storybook

## Description

- Builds 5 new UI primitives for the Dashboard in Storybook
- Renames two semantic color tokens for companion-voice consistency
- Adds `--radius-rows` token at 8px

## Changes

**New primitives (each with a `.tsx` component + `.stories.tsx`):**

- **SectionTitle** — quiet uppercase label that establishes section rhythm (14px, 500, pewter-mute). Supports optional `eyebrow` and `action` slots.
- **PageHeader** — personal greeting at top of Dashboard. `greeting`, `name`, `date` props; optional right-side `action` slot. 28px heading, 32px bottom margin.
- **InsightCard** — observation-only card for the "Noticed" section. `body` typed as `string` (not ReactNode) to enforce companion voice at the type level. Supports optional `eyebrow`.
- **MetricCard** — stat tile for the Quick Stats row. 36px tabular-nums value. `secondary` prop supports `+`/`-` prefix coloring (moss-positive / rust-negative). Loading state renders pulse-animated skeleton blocks via injected `<style>` tag (no external CSS).
- **ActivityRow** — full-row-clickable activity entry in two variants. `compact` (Dashboard): single line, dot + type on left, duration + timestamp on right. `full` (Activities page): two lines with optional `highlight`; `PR:` prefix in highlight renders in saffron-mark. Wrapper div carries the row separator so the button's border-radius is unobstructed for the pill hover effect.

**Token changes (`tokens.css` + story references updated):**

- `--color-moss-success` → `--color-moss-positive`
- `--color-rust-warning` → `--color-rust-negative`
- Added `--radius-rows: 8px`

## Testing

- All 5 components verified in Storybook (`npm run storybook`)
- `npx tsc --noEmit` — no errors in new files
- `npm run lint && npm run lint:css && npm run lint:md` — all clean

## Screenshots

Storybook stories cover: Default, variants, edge cases (long values, zero states, loading), list compositions, and InContext stories showing each primitive alongside its neighbors.

## Additional Comments

ActivityRow critique applied mid-implementation:
- Separator dot color fixed (`--color-linen-border` → `--color-pewter-mute`)
- Duration differentiated from timestamp (500 weight smoke-ink vs 400 pewter-mute)
- Full-variant row heights locked via hidden placeholder line — consistent whether or not `highlight` is present
- Hairline row separators live on a wrapper `<div>` so the button's `borderRadius` is free for the pill hover

# Checklist

- [x] All tests are passing
- [x] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly