### PR TITLE
Feat(ui): compose Dashboard with companion voice

### DIFF
--- a/fit-track-ui/react/src/components/ui/ActivityRow/ActivityRow.stories.tsx
+++ b/fit-track-ui/react/src/components/ui/ActivityRow/ActivityRow.stories.tsx
@@ -10,33 +10,19 @@ const meta: Meta<typeof ActivityRow> = {
         docs: {
             description: {
                 component:
-                    "Full-row-clickable activity entry. Two variants: `compact` for the Dashboard's Recent Activity list (single line, no highlight); `full` for the Activities page (two lines, highlight shown). The type dot color is derived from the workout type name — strength types glow saffron, cardio types go moss-positive.",
+                    "Full-row-clickable activity entry. Two variants: `compact` for the Dashboard's Recent Activity list (single inline row: type · highlight (routineContext) PR · duration · timestamp); `full` for the Activities page (two lines). Type dot color is driven by a TYPE_COLOR_MAP — Strength → saffron, Run → moss-positive, others → pewter.",
             },
         },
     },
     tags: ["autodocs"],
     argTypes: {
-        type: {
-            control: "text",
-            description: "Workout type label (e.g. \"Push\", \"Cardio\")",
-        },
-        timestamp: {
-            control: "text",
-            description: "Pre-formatted date/time string",
-        },
-        duration: {
-            control: "text",
-            description: "Pre-formatted duration string",
-        },
-        highlight: {
-            control: "text",
-            description: "Optional highlight text (PR, notable event)",
-        },
-        variant: {
-            control: "radio",
-            options: ["compact", "full"],
-            description: "compact = Dashboard single-line · full = Activities two-line",
-        },
+        type: { control: "text", description: "Workout type label" },
+        timestamp: { control: "text", description: "Pre-formatted date/time string" },
+        duration: { control: "text", description: "Pre-formatted duration string" },
+        highlight: { control: "text", description: "Exercise or event highlight" },
+        routineContext: { control: "text", description: "Routine day context — shown in parens after highlight" },
+        highlightIsPR: { control: "boolean", description: "True renders saffron PR badge" },
+        variant: { control: "radio", options: ["compact", "full"] },
     },
 };
 
@@ -45,196 +31,181 @@ export default meta;
 type Story = StoryObj<typeof ActivityRow>;
 
 /* ----------------------------------------------------------------------------
- * CompactDefault — typical Dashboard row
+ * CompactDefault — Strength row, no PR, no routineContext
  * ---------------------------------------------------------------------------- */
 
 export const CompactDefault: Story = {
     args: {
-        type: "Push",
+        type: "Strength",
         timestamp: "Mon, Jun 9",
-        duration: "48 min",
+        duration: "48m",
+        highlight: "Squat 225×5",
         variant: "compact",
     },
 };
 
 /* ----------------------------------------------------------------------------
- * CompactNoHighlight — no highlight prop in compact (not rendered anyway)
- * Shows that compact gracefully ignores the highlight prop.
+ * CompactWithContext — Strength row with routineContext
  * ---------------------------------------------------------------------------- */
 
-export const CompactNoHighlight: Story = {
+export const CompactWithContext: Story = {
     args: {
-        type: "Cardio",
-        timestamp: "Sat, Jun 7",
-        duration: "32 min",
-        highlight: "7.2 km", // ignored in compact
+        type: "Strength",
+        timestamp: "Mon, Jun 9",
+        duration: "52m",
+        highlight: "Bench 185×5",
+        routineContext: "Push Day 1",
         variant: "compact",
     },
 };
 
 /* ----------------------------------------------------------------------------
- * FullDefault — Activities page row, no highlight
+ * CompactWithPR — highlight + routineContext + PR badge
+ * ---------------------------------------------------------------------------- */
+
+export const CompactWithPR: Story = {
+    args: {
+        type: "Strength",
+        timestamp: "2h ago",
+        duration: "52m",
+        highlight: "Bench 185×5",
+        routineContext: "Push Day 1",
+        highlightIsPR: true,
+        variant: "compact",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * CompactRun — no routineContext (Run type), moss-positive dot
+ * ---------------------------------------------------------------------------- */
+
+export const CompactRun: Story = {
+    args: {
+        type: "Run",
+        timestamp: "Sun",
+        duration: "32m",
+        highlight: "3.1 mi",
+        variant: "compact",
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * FullDefault — two-line layout, no highlight
  * ---------------------------------------------------------------------------- */
 
 export const FullDefault: Story = {
     args: {
         type: "Pull",
         timestamp: "Tue, Jun 10",
-        duration: "55 min",
+        duration: "55m",
         variant: "full",
     },
 };
 
 /* ----------------------------------------------------------------------------
- * FullWithHighlight — Activities page row with PR notation
+ * FullWithPR — full variant with PR badge prefix
  * ---------------------------------------------------------------------------- */
 
-export const FullWithHighlight: Story = {
+export const FullWithPR: Story = {
     args: {
-        type: "Legs",
+        type: "Strength",
         timestamp: "Mon, Jun 9",
-        duration: "1h 12min",
-        highlight: "PR: 225 lbs squat",
+        duration: "1h 12m",
+        highlight: "225 lbs squat",
+        highlightIsPR: true,
         variant: "full",
     },
 };
 
 /* ----------------------------------------------------------------------------
- * DotColors — all three dot color categories side by side (compact)
+ * DotColors — saffron / moss-positive / pewter-mute side by side
  * ---------------------------------------------------------------------------- */
 
 export const DotColors: Story = {
     render: () => (
-        <div style={{ display: "flex", flexDirection: "column", maxWidth: "400px" }}>
-            <ActivityRow type="Push" timestamp="Mon, Jun 9" duration="48 min" variant="compact" />
-            <ActivityRow type="Run" timestamp="Sun, Jun 8" duration="32 min" variant="compact" />
-            <ActivityRow type="Mobility" timestamp="Sat, Jun 7" duration="20 min" variant="compact" />
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: "480px" }}>
+            <ActivityRow type="Strength" timestamp="Mon, Jun 9" duration="48m" highlight="Bench 185×5" routineContext="Push Day 1" variant="compact" />
+            <ActivityRow type="Run"      timestamp="Sun, Jun 8" duration="32m" highlight="3.1 mi"      variant="compact" />
+            <ActivityRow type="Mobility" timestamp="Sat, Jun 7" duration="20m" highlight="Hip mobility" variant="compact" />
         </div>
     ),
 };
 
 /* ----------------------------------------------------------------------------
- * HoverState — wrapped in a list to make hover easy to test
+ * HoverState — hover any row to see pill background
  * ---------------------------------------------------------------------------- */
 
 export const HoverState: Story = {
     render: () => (
-        <div style={{ display: "flex", flexDirection: "column", maxWidth: "400px" }}>
-            <ActivityRow
-                type="Push"
-                timestamp="Mon, Jun 9"
-                duration="48 min"
-                variant="compact"
-                onClick={() => console.log("Push clicked")}
-            />
-            <ActivityRow
-                type="Pull"
-                timestamp="Sun, Jun 8"
-                duration="52 min"
-                variant="compact"
-                onClick={() => console.log("Pull clicked")}
-            />
-            <ActivityRow
-                type="Legs"
-                timestamp="Fri, Jun 6"
-                duration="1h 12min"
-                variant="compact"
-                onClick={() => console.log("Legs clicked")}
-            />
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: "540px" }}>
+            <ActivityRow type="Strength" timestamp="2h ago"     duration="52m" highlight="Bench 185×5"    routineContext="Push Day 1" highlightIsPR={true}  variant="compact" onClick={() => {}} />
+            <ActivityRow type="Strength" timestamp="Yesterday"  duration="48m" highlight="Squat 225×5"    routineContext="Legs Day 1"                        variant="compact" onClick={() => {}} />
+            <ActivityRow type="Run"      timestamp="Sun"        duration="32m" highlight="3.1 mi"                                                             variant="compact" onClick={() => {}} />
         </div>
     ),
 };
 
 /* ----------------------------------------------------------------------------
- * ListOfRows — compact list as it appears on Dashboard
+ * ListOfRows — compact list as on Dashboard (activeUserData equivalent)
  * ---------------------------------------------------------------------------- */
 
 export const ListOfRows: Story = {
     render: () => (
-        <div style={{ display: "flex", flexDirection: "column", maxWidth: "480px" }}>
-            <ActivityRow type="Push" timestamp="Mon, Jun 9" duration="48 min" variant="compact" />
-            <ActivityRow type="Cardio" timestamp="Sun, Jun 8" duration="32 min" variant="compact" />
-            <ActivityRow type="Pull" timestamp="Fri, Jun 6" duration="52 min" variant="compact" />
-            <ActivityRow type="Legs" timestamp="Wed, Jun 4" duration="1h 12min" variant="compact" />
-            <ActivityRow type="Upper Body" timestamp="Mon, Jun 2" duration="44 min" variant="compact" />
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                maxWidth: "540px",
+                border: "1px solid var(--color-linen-border)",
+                borderRadius: "var(--radius-cards)",
+                overflow: "hidden",
+            }}
+        >
+            <ActivityRow type="Strength" timestamp="2h ago"    duration="52m" highlight="Bench 185×5"    routineContext="Push Day 1" highlightIsPR={true}  variant="compact" />
+            <ActivityRow type="Strength" timestamp="Yesterday" duration="48m" highlight="Squat 225×5"    routineContext="Legs Day 1"                        variant="compact" />
+            <ActivityRow type="Strength" timestamp="Mon"       duration="1h 5m" highlight="Deadlift 315×3" routineContext="Pull Day 1" highlightIsPR={true} variant="compact" />
+            <ActivityRow type="Run"      timestamp="Sun"       duration="32m" highlight="3.1 mi"                                                            variant="compact" />
+            <ActivityRow type="Strength" timestamp="Sat"       duration="55m" highlight="Pull 12 sets"   routineContext="Pull Day 2"                        variant="compact" />
         </div>
     ),
 };
 
 /* ----------------------------------------------------------------------------
- * FullList — full variant as it appears on Activities page
+ * FullList — full variant with mixed highlight/PR/no-highlight
  * ---------------------------------------------------------------------------- */
 
 export const FullList: Story = {
     render: () => (
         <div style={{ display: "flex", flexDirection: "column", maxWidth: "600px" }}>
-            <ActivityRow
-                type="Push"
-                timestamp="Mon, Jun 9"
-                duration="48 min"
-                highlight="PR: 225 lbs bench"
-                variant="full"
-            />
-            <ActivityRow
-                type="Cardio"
-                timestamp="Sun, Jun 8"
-                duration="32 min"
-                highlight="7.2 km"
-                variant="full"
-            />
-            <ActivityRow
-                type="Pull"
-                timestamp="Fri, Jun 6"
-                duration="52 min"
-                variant="full"
-            />
-            <ActivityRow
-                type="Legs"
-                timestamp="Wed, Jun 4"
-                duration="1h 12min"
-                highlight="PR: 315 lbs deadlift"
-                variant="full"
-            />
-            <ActivityRow
-                type="Mobility"
-                timestamp="Mon, Jun 2"
-                duration="20 min"
-                variant="full"
-            />
+            <ActivityRow type="Strength" timestamp="Mon, Jun 9" duration="52m"   highlight="Bench 185×5"    highlightIsPR={true}  variant="full" />
+            <ActivityRow type="Run"      timestamp="Sun, Jun 8" duration="32m"   highlight="3.1 mi"                               variant="full" />
+            <ActivityRow type="Strength" timestamp="Fri, Jun 6" duration="55m"                                                    variant="full" />
+            <ActivityRow type="Strength" timestamp="Wed, Jun 4" duration="1h 12m" highlight="Deadlift 315×3" highlightIsPR={true} variant="full" />
+            <ActivityRow type="Mobility" timestamp="Mon, Jun 2" duration="20m"                                                    variant="full" />
         </div>
     ),
 };
 
 /* ----------------------------------------------------------------------------
- * InContext — SectionTitle + compact list (Dashboard-style)
+ * InContext — SectionTitle("Recent activity") + compact list
  * ---------------------------------------------------------------------------- */
 
 export const InContext: Story = {
     render: () => (
-        <div style={{ maxWidth: "480px" }}>
+        <div style={{ maxWidth: "540px" }}>
             <SectionTitle>Recent activity</SectionTitle>
-            <div style={{ display: "flex", flexDirection: "column" }}>
-                <ActivityRow
-                    type="Push"
-                    timestamp="Mon, Jun 9"
-                    duration="48 min"
-                    variant="compact"
-                    onClick={() => console.log("Navigate to Push detail")}
-                />
-                <ActivityRow
-                    type="Cardio"
-                    timestamp="Sun, Jun 8"
-                    duration="32 min"
-                    variant="compact"
-                    onClick={() => console.log("Navigate to Cardio detail")}
-                />
-                <ActivityRow
-                    type="Pull"
-                    timestamp="Fri, Jun 6"
-                    duration="52 min"
-                    variant="compact"
-                    onClick={() => console.log("Navigate to Pull detail")}
-                />
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    border: "1px solid var(--color-linen-border)",
+                    borderRadius: "var(--radius-cards)",
+                    overflow: "hidden",
+                }}
+            >
+                <ActivityRow type="Strength" timestamp="2h ago"    duration="52m"   highlight="Bench 185×5" routineContext="Push Day 1" highlightIsPR={true} variant="compact" onClick={() => {}} />
+                <ActivityRow type="Strength" timestamp="Yesterday" duration="48m"   highlight="Squat 225×5" routineContext="Legs Day 1"                      variant="compact" onClick={() => {}} />
+                <ActivityRow type="Run"      timestamp="Sun"       duration="32m"   highlight="3.1 mi"                                                       variant="compact" onClick={() => {}} />
             </div>
         </div>
     ),

--- a/fit-track-ui/react/src/components/ui/ActivityRow/ActivityRow.tsx
+++ b/fit-track-ui/react/src/components/ui/ActivityRow/ActivityRow.tsx
@@ -3,25 +3,26 @@
  * ----------------------------------------------------------------------------
  * A full-row-clickable activity entry used in two contexts:
  *
- *   compact  — Dashboard "Recent Activity" list. Single line: type on left,
- *              duration + timestamp on right. No highlight.
+ *   compact  — Dashboard "Recent Activity" list. Single inline row:
+ *              [dot] [type] · [highlight] [(routineContext)] [PR] · [duration] · [timestamp]
+ *              Type and highlight anchor left; duration+timestamp anchor right.
+ *              routineContext is the most truncatable element; highlight and
+ *              type never truncate.
  *
- *   full     — Activities page. Two lines: type + optional highlight on the
- *              left column; timestamp + duration on the right column.
+ *   full     — Activities page. Two lines: type + highlight on the left
+ *              column; timestamp + duration on the right column.
  *
  * Rendered as a <button> so the entire row is keyboard-accessible. The caller
  * is responsible for navigation (push to workout detail, etc.).
  *
- * Type dot color is derived from the workout type name:
- *   strength keywords (Push/Pull/Legs/Upper/Lower/Full/Strength) → saffron
- *   cardio keywords (Run/Cardio/Bike/Swim/Walk/HIIT)             → moss-positive
- *   everything else                                              → pewter-mute
+ * Type dot color is driven by a TYPE_COLOR_MAP (exact match, then pewter-mute
+ * fallback). This is a placeholder pending the broader chart/type color system.
+ *   Strength → saffron-mark
+ *   Run      → moss-positive
+ *   others   → pewter-mute
  *
- * Highlight parsing: if highlight starts with "PR:" the prefix renders in
- * --color-saffron-mark (500 weight); the rest renders in --color-charcoal-ink.
- * All other highlights render in --color-charcoal-ink at 400 weight.
- * A hidden placeholder line is always reserved in full variant so row heights
- * are consistent whether or not a highlight is present.
+ * PR badge: `highlightIsPR` renders an inline "PR" label in saffron-mark (10px
+ * 500, 0.05em tracking) in compact, and a "PR:" prefix in saffron in full.
  *
  * Used by:
  *   - Dashboard ("Recent Activity" section, compact variant)
@@ -33,9 +34,9 @@
  *   - --color-linen-border      (row bottom separator)
  *   - --color-charcoal-ink      (type + highlight text)
  *   - --color-smoke-ink         (duration text)
- *   - --color-pewter-mute       (timestamp, separator dot, default dot)
- *   - --color-saffron-mark      (strength-type dot + "PR:" prefix)
- *   - --color-moss-positive     (cardio-type dot)
+ *   - --color-pewter-mute       (timestamp, separator dot, routineContext, default dot)
+ *   - --color-saffron-mark      (Strength dot + PR badge)
+ *   - --color-moss-positive     (Run dot)
  *   - --color-indigo-press      (focus ring)
  *   - --font-aeonikpro          (all text)
  *   - --radius-rows             (hover background radius)
@@ -45,7 +46,7 @@
  *
  * Accessibility:
  *   - Full row is a <button> — keyboard activation via Enter/Space.
- *   - aria-label: "{type} · {duration}{highlight ? ' · ' + highlight : ''}"
+ *   - aria-label built from type · duration · highlight · routineContext
  *   - Visible focus ring on keyboard focus only (mirrors PillNavigationItem).
  * ============================================================================ */
 
@@ -55,51 +56,64 @@ import type { ButtonHTMLAttributes } from "react";
 type ActivityVariant = "compact" | "full";
 
 interface ActivityRowProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "type"> {
-    /** Workout type label (e.g., "Push", "Pull", "Legs", "Cardio"). */
+    /** Workout type label (e.g., "Strength", "Run"). Drives dot color. */
     type: string;
-    /** Pre-formatted timestamp string (e.g., "Mon, Jun 9" or "Today, 9:41 AM"). */
+    /** Pre-formatted timestamp string (e.g., "Mon, Jun 9" or "2h ago"). */
     timestamp: string;
-    /** Pre-formatted duration string (e.g., "48 min", "1h 12min"). */
+    /** Pre-formatted duration string (e.g., "48m", "1h 12m"). */
     duration: string;
-    /** Optional highlight — personal record or notable event.
-     *  If it starts with "PR:" the prefix renders in saffron-mark. */
+    /** Exercise or event highlight (e.g., "Bench 185×5", "3.1 mi"). */
     highlight?: string;
+    /** Routine day context (e.g., "Push Day 1"). Shown in parens after highlight.
+     *  Omit for non-routine activity types (Run, Yoga). */
+    routineContext?: string;
+    /** True renders a saffron "PR" badge after the routineContext in compact,
+     *  or a "PR:" prefix in full. */
+    highlightIsPR?: boolean;
     /** "compact" → single-line Dashboard row. "full" → two-line Activities row.
      *  Defaults to "compact". */
     variant?: ActivityVariant;
 }
 
-const STRENGTH_KEYWORDS = /push|pull|legs|upper|lower|full|strength|lift|squat|deadlift/i;
-const CARDIO_KEYWORDS = /run|cardio|bike|swim|walk|hike|hiit|row|cycle|elliptical/i;
+/* Placeholder type→color map. Expand as the type system grows.
+ * Exact string match only — no substring matching. */
+const TYPE_COLOR_MAP: Record<string, string> = {
+    Strength: "var(--color-saffron-mark)",
+    Run:      "var(--color-moss-positive)",
+};
 
-function dotColor(type: string): string {
-    if (STRENGTH_KEYWORDS.test(type)) return "var(--color-saffron-mark)";
-    if (CARDIO_KEYWORDS.test(type)) return "var(--color-moss-positive)";
-    return "var(--color-pewter-mute)";
+function getDotColor(type: string): string {
+    return TYPE_COLOR_MAP[type] ?? "var(--color-pewter-mute)";
 }
 
-function buildAriaLabel(type: string, duration: string, highlight?: string): string {
+function buildAriaLabel(
+    type: string,
+    duration: string,
+    highlight?: string,
+    routineContext?: string,
+    highlightIsPR?: boolean,
+): string {
     let label = `${type} · ${duration}`;
-    if (highlight) label += ` · ${highlight}`;
-    return label;
-}
-
-/* Render highlight text. "PR:" prefix gets saffron treatment; rest is charcoal. */
-function HighlightText({ text }: { text: string }) {
-    if (text.startsWith("PR:")) {
-        return (
-            <>
-                <span style={{ color: "var(--color-saffron-mark)", fontWeight: 500 }}>PR:</span>
-                <span style={{ color: "var(--color-charcoal-ink)" }}>{text.slice(3)}</span>
-            </>
-        );
+    if (highlight) {
+        label += ` · ${highlightIsPR ? "PR: " : ""}${highlight}`;
+        if (routineContext) label += ` (${routineContext})`;
     }
-    return <span style={{ color: "var(--color-charcoal-ink)" }}>{text}</span>;
+    return label;
 }
 
 export const ActivityRow = forwardRef<HTMLButtonElement, ActivityRowProps>(
     function ActivityRow(
-        { type, timestamp, duration, highlight, variant = "compact", className, ...rest },
+        {
+            type,
+            timestamp,
+            duration,
+            highlight,
+            routineContext,
+            highlightIsPR = false,
+            variant = "compact",
+            className,
+            ...rest
+        },
         ref,
     ) {
         const [hovered, setHovered] = useState(false);
@@ -116,7 +130,7 @@ export const ActivityRow = forwardRef<HTMLButtonElement, ActivityRowProps>(
                 <button
                     ref={ref}
                     type="button"
-                    aria-label={buildAriaLabel(type, duration, highlight)}
+                    aria-label={buildAriaLabel(type, duration, highlight, routineContext, highlightIsPR)}
                     onMouseEnter={() => setHovered(true)}
                     onMouseLeave={() => setHovered(false)}
                     onFocus={(e) => {
@@ -124,25 +138,21 @@ export const ActivityRow = forwardRef<HTMLButtonElement, ActivityRowProps>(
                     }}
                     onBlur={() => setFocusVisible(false)}
                     style={{
-                    // Reset button chrome
                         border: "none",
                         cursor: "pointer",
                         textAlign: "left",
                         width: "100%",
 
-                        // Layout
                         display: "flex",
                         flexDirection: "row",
-                        alignItems: variant === "full" ? "flex-start" : "center",
+                        alignItems: variant === "compact" ? "baseline" : "flex-start",
                         justifyContent: "space-between",
                         padding: `${paddingY} var(--spacing-8)`,
                         gap: "var(--spacing-16)",
 
-                        // Pill hover — borderRadius free because separator lives on wrapper
                         backgroundColor: hovered ? "var(--color-vellum-surface)" : "transparent",
                         borderRadius: "var(--radius-rows)",
 
-                        // Focus ring (keyboard only)
                         outline: "none",
                         boxShadow: focusVisible
                             ? "0 0 0 2px var(--color-paper-canvas), 0 0 0 4px var(--color-indigo-press)"
@@ -152,129 +162,276 @@ export const ActivityRow = forwardRef<HTMLButtonElement, ActivityRowProps>(
                     }}
                     {...rest}
                 >
-                    {/* Left column */}
-                    <div
-                        style={{
-                            display: "flex",
-                            flexDirection: "column",
-                            gap: "var(--spacing-4)",
-                            minWidth: 0,
-                        }}
-                    >
-                        {/* Type row: dot + label */}
-                        <div
-                            style={{
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "var(--spacing-8)",
-                            }}
-                        >
+                    {variant === "compact" ? (
+                        // ── Compact ───────────────────────────────────────────
+                        // Single inline flex row. Left side (flex:1) holds the training
+                        // narrative; right side (flexShrink:0) anchors duration+timestamp.
+                        <>
+                            {/* Left: dot · type · highlight · routineContext · PR */}
                             <span
-                                aria-hidden="true"
+                                style={{
+                                    display: "flex",
+                                    alignItems: "center",
+                                    flex: 1,
+                                    minWidth: 0,
+                                }}
+                            >
+                                {/* Type dot */}
+                                <span
+                                    aria-hidden="true"
+                                    style={{
+                                        flexShrink: 0,
+                                        display: "inline-block",
+                                        width: "8px",
+                                        height: "8px",
+                                        borderRadius: "9999px",
+                                        backgroundColor: getDotColor(type),
+                                        marginRight: "8px",
+                                    }}
+                                />
+                                {/* Type */}
+                                <span
+                                    style={{
+                                        flexShrink: 0,
+                                        fontFamily: "var(--font-aeonikpro)",
+                                        fontSize: "14px",
+                                        fontWeight: 500,
+                                        color: "var(--color-charcoal-ink)",
+                                        lineHeight: 1.3,
+                                    }}
+                                >
+                                    {type}
+                                </span>
+
+                                {/* Highlight + routineContext + PR badge */}
+                                {highlight && (
+                                    <span
+                                        style={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            minWidth: 0,
+                                            flex: 1,
+                                        }}
+                                    >
+                                        {/* Separator */}
+                                        <span
+                                            aria-hidden="true"
+                                            style={{
+                                                flexShrink: 0,
+                                                margin: "0 8px",
+                                                color: "var(--color-pewter-mute)",
+                                                fontSize: "15px",
+                                                fontWeight: 400,
+                                            }}
+                                        >
+                                            ·
+                                        </span>
+                                        {/* Highlight */}
+                                        <span
+                                            style={{
+                                                flexShrink: 0,
+                                                fontFamily: "var(--font-aeonikpro)",
+                                                fontSize: "14px",
+                                                fontWeight: 500,
+                                                color: "var(--color-charcoal-ink)",
+                                                lineHeight: 1.3,
+                                            }}
+                                        >
+                                            {highlight}
+                                        </span>
+                                        {/* routineContext — truncates first under pressure */}
+                                        {routineContext && (
+                                            <span
+                                                style={{
+                                                    flexShrink: 1,
+                                                    minWidth: 0,
+                                                    overflow: "hidden",
+                                                    textOverflow: "ellipsis",
+                                                    whiteSpace: "nowrap",
+                                                    fontFamily: "var(--font-aeonikpro)",
+                                                    fontSize: "13px",
+                                                    fontWeight: 400,
+                                                    color: "var(--color-pewter-mute)",
+                                                    marginLeft: "4px",
+                                                    lineHeight: 1.3,
+                                                }}
+                                            >
+                                                ({routineContext})
+                                            </span>
+                                        )}
+                                        {/* PR badge */}
+                                        {highlightIsPR && (
+                                            <span
+                                                style={{
+                                                    flexShrink: 0,
+                                                    marginLeft: "6px",
+                                                    fontFamily: "var(--font-aeonikpro)",
+                                                    fontSize: "11px",
+                                                    fontWeight: 500,
+                                                    color: "var(--color-saffron-mark)",
+                                                    letterSpacing: "0.05em",
+                                                    lineHeight: 1.3,
+                                                }}
+                                            >
+                                                PR
+                                            </span>
+                                        )}
+                                    </span>
+                                )}
+                            </span>
+
+                            {/* Right: duration · timestamp */}
+                            <span
                                 style={{
                                     flexShrink: 0,
-                                    width: "7px",
-                                    height: "7px",
-                                    borderRadius: "9999px",
-                                    backgroundColor: dotColor(type),
-                                }}
-                            />
-                            <span
-                                style={{
                                     fontFamily: "var(--font-aeonikpro)",
-                                    fontSize: "15px",
-                                    fontWeight: 500,
-                                    color: "var(--color-charcoal-ink)",
                                     lineHeight: 1.3,
                                     whiteSpace: "nowrap",
-                                    overflow: "hidden",
-                                    textOverflow: "ellipsis",
                                 }}
                             >
-                                {type}
+                                <span
+                                    style={{
+                                        fontSize: "14px",
+                                        fontWeight: 500,
+                                        color: "var(--color-smoke-ink)",
+                                    }}
+                                >
+                                    {duration}
+                                </span>
+                                <span
+                                    aria-hidden="true"
+                                    style={{ margin: "0 7px", fontSize: "14px", color: "var(--color-pewter-mute)" }}
+                                >
+                                    ·
+                                </span>
+                                <span
+                                    style={{
+                                        fontSize: "12px",
+                                        fontWeight: 400,
+                                        color: "var(--color-pewter-mute)",
+                                    }}
+                                >
+                                    {timestamp}
+                                </span>
                             </span>
-                        </div>
-
-                        {/* Highlight line — full variant only.
-                        Always rendered (visible or hidden) to lock row height. */}
-                        {variant === "full" && (
-                            <span
-                                aria-hidden={!highlight || undefined}
-                                style={{
-                                    fontFamily: "var(--font-aeonikpro)",
-                                    fontSize: "13px",
-                                    fontWeight: 400,
-                                    lineHeight: 1.4,
-                                    paddingLeft: "15px", // aligns with type text (7px dot + 8px gap)
-                                    visibility: highlight ? "visible" : "hidden",
-                                }}
-                            >
-                                {highlight ? <HighlightText text={highlight} /> : "​"}
-                            </span>
-                        )}
-                    </div>
-
-                    {/* Right column */}
-                    {variant === "compact" ? (
-                    // Compact: duration (smoke-ink, 500) · timestamp (pewter-mute, 400)
-                        <span
-                            style={{
-                                flexShrink: 0,
-                                fontFamily: "var(--font-aeonikpro)",
-                                fontSize: "13px",
-                                lineHeight: 1.3,
-                                whiteSpace: "nowrap",
-                            }}
-                        >
-                            <span style={{ fontWeight: 500, color: "var(--color-smoke-ink)" }}>
-                                {duration}
-                            </span>
-                            <span
-                                aria-hidden="true"
-                                style={{ margin: "0 5px", color: "var(--color-pewter-mute)" }}
-                            >
-                            ·
-                            </span>
-                            <span style={{ fontWeight: 400, color: "var(--color-pewter-mute)" }}>
-                                {timestamp}
-                            </span>
-                        </span>
+                        </>
                     ) : (
-                    // Full: timestamp (pewter-mute, 400) on top; duration (smoke-ink, 500) below
-                        <div
-                            style={{
-                                flexShrink: 0,
-                                display: "flex",
-                                flexDirection: "column",
-                                alignItems: "flex-end",
-                                gap: "var(--spacing-4)",
-                            }}
-                        >
-                            <span
+                        // ── Full ──────────────────────────────────────────────
+                        // Two-line layout. Left: type header + highlight line.
+                        // Right: timestamp on top, duration below.
+                        <>
+                            {/* Left column */}
+                            <div
                                 style={{
-                                    fontFamily: "var(--font-aeonikpro)",
-                                    fontSize: "13px",
-                                    fontWeight: 400,
-                                    color: "var(--color-pewter-mute)",
-                                    lineHeight: 1.3,
-                                    whiteSpace: "nowrap",
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    gap: "var(--spacing-4)",
+                                    minWidth: 0,
                                 }}
                             >
-                                {timestamp}
-                            </span>
-                            <span
+                                {/* Type row: dot + label */}
+                                <div
+                                    style={{
+                                        display: "flex",
+                                        alignItems: "center",
+                                        gap: "var(--spacing-8)",
+                                    }}
+                                >
+                                    <span
+                                        aria-hidden="true"
+                                        style={{
+                                            flexShrink: 0,
+                                            width: "8px",
+                                            height: "8px",
+                                            borderRadius: "9999px",
+                                            backgroundColor: getDotColor(type),
+                                        }}
+                                    />
+                                    <span
+                                        style={{
+                                            fontFamily: "var(--font-aeonikpro)",
+                                            fontSize: "15px",
+                                            fontWeight: 500,
+                                            color: "var(--color-charcoal-ink)",
+                                            lineHeight: 1.3,
+                                            whiteSpace: "nowrap",
+                                            overflow: "hidden",
+                                            textOverflow: "ellipsis",
+                                        }}
+                                    >
+                                        {type}
+                                    </span>
+                                </div>
+
+                                {/* Highlight line — always rendered to lock row height */}
+                                <span
+                                    aria-hidden={!highlight || undefined}
+                                    style={{
+                                        fontFamily: "var(--font-aeonikpro)",
+                                        fontSize: "13px",
+                                        fontWeight: 400,
+                                        lineHeight: 1.4,
+                                        paddingLeft: "15px",
+                                        visibility: highlight ? "visible" : "hidden",
+                                    }}
+                                >
+                                    {highlight ? (
+                                        <>
+                                            {highlightIsPR && (
+                                                <span
+                                                    style={{
+                                                        color: "var(--color-saffron-mark)",
+                                                        fontWeight: 500,
+                                                        marginRight: "4px",
+                                                    }}
+                                                >
+                                                    PR:
+                                                </span>
+                                            )}
+                                            <span style={{ color: "var(--color-charcoal-ink)" }}>
+                                                {highlight}
+                                            </span>
+                                        </>
+                                    ) : "​"}
+                                </span>
+                            </div>
+
+                            {/* Right column: timestamp + duration */}
+                            <div
                                 style={{
-                                    fontFamily: "var(--font-aeonikpro)",
-                                    fontSize: "13px",
-                                    fontWeight: 500,
-                                    color: "var(--color-smoke-ink)",
-                                    lineHeight: 1.3,
-                                    whiteSpace: "nowrap",
+                                    flexShrink: 0,
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    alignItems: "flex-end",
+                                    gap: "var(--spacing-4)",
                                 }}
                             >
-                                {duration}
-                            </span>
-                        </div>
+                                <span
+                                    style={{
+                                        fontFamily: "var(--font-aeonikpro)",
+                                        fontSize: "13px",
+                                        fontWeight: 400,
+                                        color: "var(--color-pewter-mute)",
+                                        lineHeight: 1.3,
+                                        whiteSpace: "nowrap",
+                                    }}
+                                >
+                                    {timestamp}
+                                </span>
+                                <span
+                                    style={{
+                                        fontFamily: "var(--font-aeonikpro)",
+                                        fontSize: "13px",
+                                        fontWeight: 500,
+                                        color: "var(--color-smoke-ink)",
+                                        lineHeight: 1.3,
+                                        whiteSpace: "nowrap",
+                                    }}
+                                >
+                                    {duration}
+                                </span>
+                            </div>
+                        </>
                     )}
                 </button>
             </div>

--- a/fit-track-ui/react/src/components/ui/SectionTitle/SectionTitle.tsx
+++ b/fit-track-ui/react/src/components/ui/SectionTitle/SectionTitle.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { ReactNode } from "react";
 
 /* ============================================================================
@@ -41,6 +42,8 @@ interface SectionTitleProps {
 }
 
 export function SectionTitle({ children, action, eyebrow, className }: SectionTitleProps) {
+    const [actionHovered, setActionHovered] = useState(false);
+
     return (
         <div
             className={className}
@@ -90,9 +93,21 @@ export function SectionTitle({ children, action, eyebrow, className }: SectionTi
                 </span>
             </div>
 
-            {/* Right: optional action (pushed to far edge via space-between) */}
+            {/* Right: optional action — indigo-signal, 500 weight, hover shifts to indigo-press */}
             {action && (
-                <div style={{ flexShrink: 0 }}>
+                <div
+                    style={{
+                        flexShrink: 0,
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "13px",
+                        fontWeight: 500,
+                        color: actionHovered ? "var(--color-indigo-press)" : "var(--color-indigo-signal)",
+                        cursor: "pointer",
+                        transition: "color 120ms ease",
+                    }}
+                    onMouseEnter={() => setActionHovered(true)}
+                    onMouseLeave={() => setActionHovered(false)}
+                >
                     {action}
                 </div>
             )}

--- a/fit-track-ui/react/src/design-system/tokens.css
+++ b/fit-track-ui/react/src/design-system/tokens.css
@@ -60,7 +60,7 @@
 
     /* COLORS — Warm Neutrals */
     --color-paper-canvas: #FAFAF8;
-    --color-vellum-surface: #F2F1ED;
+    --color-vellum-surface: #EEEDE6;
     --color-ash-inset: #E8E7E2;
 
     /* COLORS — Ink Hierarchy */

--- a/fit-track-ui/react/src/pages/dashboard/Dashboard.stories.tsx
+++ b/fit-track-ui/react/src/pages/dashboard/Dashboard.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router-dom";
+import { Dashboard } from "./Dashboard";
+import { MockAuthProvider } from "../../components/layout/TopBar/storybook/MockAuthProvider";
+import { activeUserData, lightUserData, newUserData } from "./mock-data";
+
+const meta: Meta<typeof Dashboard> = {
+    title: "Pages / Dashboard",
+    component: Dashboard,
+    parameters: {
+        layout: "padded",
+        docs: {
+            description: {
+                component:
+                    "Full Dashboard composition. Four sections: PageHeader, Quick Stats, Recent Activity, Noticed. Each section applies companion voice rules — observations only, no directives. The Noticed section is omitted entirely when no insight exists.",
+            },
+        },
+    },
+    decorators: [
+        (Story) => (
+            <MemoryRouter initialEntries={["/dashboard"]}>
+                <MockAuthProvider>
+                    <div
+                        style={{
+                            backgroundColor: "var(--color-paper-canvas)",
+                            minHeight: "100vh",
+                            padding: "var(--spacing-48) var(--layout-page-padding-x)",
+                            maxWidth: "var(--layout-max-width)",
+                            margin: "0 auto",
+                        }}
+                    >
+                        <Story />
+                    </div>
+                </MockAuthProvider>
+            </MemoryRouter>
+        ),
+    ],
+    tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Dashboard>;
+
+/* ----------------------------------------------------------------------------
+ * ActiveUser — design target view
+ * 5 recent activities, all stats > 0, insight present
+ * ---------------------------------------------------------------------------- */
+
+export const ActiveUser: Story = {
+    args: {
+        data: activeUserData,
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * LightUser — sparse data state
+ * 2 activities, first-week stats, insight present
+ * ---------------------------------------------------------------------------- */
+
+export const LightUser: Story = {
+    args: {
+        data: lightUserData,
+    },
+};
+
+/* ----------------------------------------------------------------------------
+ * NewUser — honest empty state
+ * Zero activities (dashed placeholder), zero stats, no Noticed section
+ * ---------------------------------------------------------------------------- */
+
+export const NewUser: Story = {
+    args: {
+        data: newUserData,
+    },
+};

--- a/fit-track-ui/react/src/pages/dashboard/Dashboard.tsx
+++ b/fit-track-ui/react/src/pages/dashboard/Dashboard.tsx
@@ -1,320 +1,176 @@
-import {useEffect, useState} from "react";
-
+import { Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../../context/AuthContext";
+import { PageHeader } from "../../components/ui/PageHeader/PageHeader";
+import { SectionTitle } from "../../components/ui/SectionTitle/SectionTitle";
+import { MetricCard } from "../../components/ui/MetricCard/MetricCard";
+import { ActivityRow } from "../../components/ui/ActivityRow/ActivityRow";
+import { InsightCard } from "../../components/ui/InsightCard/InsightCard";
 import {
-    calculateTotalCalories,
-    calculateTotalMinutes,
-    calculateTotalVolume,
-    calculateVolumeChange,
-    filterWorkoutsThisWeek,
-    formatNumber,
-} from "../../utils/dashboardCalculations.ts";
+    type Activity,
+    type DashboardData,
+    type Insight,
+    activeUserData,
+    formatDate,
+    formatDuration,
+    formatVolume,
+    getFirstName,
+    getGreeting,
+} from "./mock-data";
 
-import {isDateInThisWeek, sortWorkoutsAsc} from "../../utils/utilities.ts";
+/* ============================================================================
+ * Secondary text builders — MetricCard companion voice rules:
+ *   - Sessions: always show "/ N target" (the target is what it is, no shame)
+ *   - Volume: delta text when non-zero; "lbs" otherwise (zero value or zero delta)
+ *   - Time: "no time logged yet" on zero value; delta text when non-zero; omit on equal weeks
+ * ============================================================================ */
 
-import "./dashboard.css";
-import {WorkoutDTO} from "../../api/generated/models";
-import {getWorkoutsApi} from "../../api/generated/endpoints/workouts-api/workouts-api.ts";
-import {authenticatedMember} from "../layout.tsx";
+function sessionsSecondary(target: number): string {
+    return `/ ${target} target`;
+}
 
-export const Dashboard = () => {
-    const member = authenticatedMember();
-    const {getAllWorkoutsByMemberId} = getWorkoutsApi();
-    const [workouts, setWorkouts] = useState<WorkoutDTO[]>([]);
+function volumeSecondary(volume: number, delta: number): string {
+    if (volume === 0) return "lbs";
+    if (delta > 0) return `+${formatVolume(delta)} lbs from last week`;
+    if (delta < 0) return `-${formatVolume(Math.abs(delta))} lbs from last week`;
+    return "lbs";
+}
 
+function timeSecondary(minutes: number, delta: number): string | undefined {
+    if (minutes === 0) return "no time logged yet";
+    if (delta > 0) return `+${formatDuration(delta)} from last week`;
+    if (delta < 0) return `-${formatDuration(Math.abs(delta))} from last week`;
+    return undefined;
+}
 
-    // Dashboard metrics state
-    const [workoutsThisWeek, setWorkoutsThisWeek] = useState<number>(0);
-    const [caloriesBurned, setCaloriesBurned] = useState<number>(0);
-    const [activeMinutes, setActiveMinutes] = useState<number>(0);
-    const [volumeLifted, setVolumeLifted] = useState<number>(0);
-    const [volumeChange, setVolumeChange] = useState<string>("0%");
-    const [isLoading, setIsLoading] = useState<boolean>(true);
+/* ============================================================================
+ * Section components — local to Dashboard, not reused elsewhere
+ * ============================================================================ */
 
-    const today = new Date();
-    const thisWeek = new Date(today);
-    thisWeek.setDate(today.getDate() - today.getDay());
-    const [weeks, setWeeks] = useState<Date[]>([]);
+function QuickStatsSection({ weekStats }: { weekStats: DashboardData["weekStats"] }) {
+    return (
+        <section>
+            <SectionTitle>This week</SectionTitle>
+            <div
+                style={{
+                    display: "grid",
+                    gridTemplateColumns: "repeat(3, 1fr)",
+                    gap: "var(--spacing-12)",
+                }}
+            >
+                <MetricCard
+                    label="Sessions"
+                    value={weekStats.sessions}
+                    secondary={sessionsSecondary(weekStats.sessionsTarget)}
+                />
+                <MetricCard
+                    label="Volume"
+                    value={`${formatVolume(weekStats.volume)} lbs`}
+                    secondary={volumeSecondary(weekStats.volume, weekStats.volumeDelta)}
+                />
+                <MetricCard
+                    label="Time trained"
+                    value={formatDuration(weekStats.timeTrainedMinutes)}
+                    secondary={timeSecondary(weekStats.timeTrainedMinutes, weekStats.timeDelta)}
+                />
+            </div>
+        </section>
+    );
+}
 
-    // Fetch workouts separately to avoid unnecessary re-renders
-    useEffect(() => {
-        const fetchWorkouts = async () => {
-            if (!member?.id) {
-                setIsLoading(false);
-                return;
-            }
+function RecentActivitySection({ activities }: { activities: Activity[] }) {
+    const navigate = useNavigate();
+    const hasActivities = activities.length > 0;
 
-            try {
-                await getAllWorkoutsByMemberId(member.id).then(setWorkouts);
-            } catch (error) {
-                console.error("Error fetching workouts:", error);
-                setWorkouts([]);
-            }
-        };
-
-        fetchWorkouts();
-    }, [member?.id]);
-
-    // Calculate dashboard metrics (Monday-Sunday week)
-    useEffect(() => {
-        if (!member || workouts.length === 0) {
-            setIsLoading(false);
-            return;
-        }
-
-        try {
-            const weekWorkouts = filterWorkoutsThisWeek(workouts);
-
-            const workoutCount = weekWorkouts.length;
-            const calories = calculateTotalCalories(weekWorkouts);
-            const minutes = calculateTotalMinutes(weekWorkouts);
-            const volume = calculateTotalVolume(weekWorkouts);
-            const change = calculateVolumeChange(weekWorkouts, workouts);
-
-            // Update state
-            setWorkoutsThisWeek(workoutCount);
-            setCaloriesBurned(calories);
-            setActiveMinutes(minutes);
-            setVolumeLifted(volume);
-            setVolumeChange(change);
-            setIsLoading(false);
-
-        } catch (error) {
-            console.error("Error calculating dashboard metrics:", error);
-            setIsLoading(false);
-        }
-    }, [member, workouts]);
-
-    useEffect(() => {
-        if (workouts.length > 0) {
-            const sortedWorkouts = sortWorkoutsAsc(workouts);
-            let date: Date;
-            const newWeeks: Date[] = [...weeks];
-
-            sortedWorkouts.forEach((workout) => {
-                date = new Date(workout.workoutDate.toString());
-
-                if (!isDateInThisWeek(date)) {
-                    if (newWeeks.length > 0) {
-                        const prevDate = newWeeks[newWeeks.length - 1];
-                        const dayOfWeek = date.getDay();
-
-                        const firstDayOfWeek = new Date(date);
-                        firstDayOfWeek.setDate(date.getDate() - (dayOfWeek === 0 ? 6 : dayOfWeek));
-                        firstDayOfWeek.setHours(0, 0, 0, 0);
-
-                        const lastDayOfWeek = new Date(prevDate);
-                        lastDayOfWeek.setDate(prevDate.getDate() + 6);
-
-                        if (date > lastDayOfWeek) {
-                            if (!newWeeks.some(week => week.getTime() === firstDayOfWeek.getTime())) {
-                                newWeeks.unshift(firstDayOfWeek);
-                            }
-                        }
-                    } else {
-                        const dayOfWeek = date.getDay();
-                        const firstDayOfWeek = new Date(date);
-                        firstDayOfWeek.setDate(date.getDate() - dayOfWeek);
-                        firstDayOfWeek.setHours(0, 0, 0, 0);
-
-                        newWeeks.push(firstDayOfWeek);
-                    }
-                } else {
-                    // setSelectedWeek(thisWeek);
-                }
-            });
-
-            setWeeks(newWeeks);
-        }
-    }, [member]);
+    const viewAllAction = hasActivities ? (
+        <Link
+            to="/activities?sort=recent"
+            style={{ color: "inherit", textDecoration: "none" }}
+        >
+            View all →
+        </Link>
+    ) : undefined;
 
     return (
-        <div className="dashboard-container">
-            {/* Tabs */}
-            <div className="tabs-container">
-                <div className="tabs-wrapper">
-                    <button className="tab-button-active">
-                        Overview
-                    </button>
-                    <button className="tab-button-inactive">
-                        Workouts
-                    </button>
-                    <button className="tab-button-inactive">
-                        Nutrition
-                    </button>
-                    <button className="tab-button-inactive">
-                        Body
-                    </button>
-                </div>
-            </div>
+        <section>
+            <SectionTitle action={viewAllAction}>Recent activity</SectionTitle>
 
-            {/* Summary Widgets */}
-            <div className="summary-widgets">
-                <div className="widget-card">
-                    <div className="widget-content">
-                        <div>
-                            <p className="widget-info">Workouts This Week</p>
-                            <p className="widget-value">
-                                {isLoading ? "..." : workoutsThisWeek}
-                            </p>
-                            <p className="widget-target">Target: 4 workouts</p>
-                        </div>
-                        <div className="widget-icon-container widget-icon-purple">
-                            <svg className="widget-icon icon-purple" fill="none" stroke="currentColor"
-                                viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                    d="M9 6v6m0 0v6m0-6h6m-6 0H9"/>
-                            </svg>
-                        </div>
-                    </div>
+            {hasActivities ? (
+                <div
+                    style={{
+                        border: "1px solid var(--color-ash-inset)",
+                        borderRadius: "var(--radius-cards)",
+                        overflow: "hidden",
+                    }}
+                >
+                    {activities.slice(0, 5).map((activity) => (
+                        <ActivityRow
+                            key={activity.id}
+                            type={activity.type}
+                            timestamp={activity.timestamp}
+                            duration={formatDuration(activity.durationMinutes)}
+                            highlight={activity.highlight}
+                            routineContext={activity.routineContext}
+                            highlightIsPR={activity.highlightIsPR}
+                            variant="compact"
+                            onClick={() => navigate(`/activities/${activity.id}`)}
+                        />
+                    ))}
                 </div>
+            ) : (
+                <div
+                    style={{
+                        border: "1px dashed var(--color-linen-border)",
+                        borderRadius: "var(--radius-cards)",
+                        padding: "var(--spacing-32) var(--spacing-24)",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        fontFamily: "var(--font-aeonikpro)",
+                        fontSize: "14px",
+                        fontWeight: 400,
+                        color: "var(--color-smoke-ink)",
+                    }}
+                >
+                    Activities you log will appear here.
+                </div>
+            )}
+        </section>
+    );
+}
 
-                <div className="widget-card">
-                    <div className="widget-content">
-                        <div>
-                            <p className="widget-info">Calories Burned</p>
-                            <p className="widget-value">
-                                {isLoading ? "..." : formatNumber(caloriesBurned)}
-                            </p>
-                            <p className="widget-target">Target: 2,500 kcal</p>
-                        </div>
-                        <div className="widget-icon-container widget-icon-orange">
-                            <svg className="widget-icon icon-orange" fill="none" stroke="currentColor"
-                                viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                    d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.777 17.656 7.343A7.975 7.975 0 0120 13a7.975 7.975 0 01-2.343 5.657z"/>
-                            </svg>
-                        </div>
-                    </div>
-                </div>
+function NoticedSection({ insight }: { insight: Insight }) {
+    return (
+        <section>
+            <InsightCard eyebrow={insight.eyebrow} body={insight.body} />
+        </section>
+    );
+}
 
-                <div className="widget-card">
-                    <div className="widget-content">
-                        <div>
-                            <p className="widget-info">Active Minutes</p>
-                            <p className="widget-value">
-                                {isLoading ? "..." : formatNumber(activeMinutes)}
-                            </p>
-                            <p className="widget-target">Target: 150 minutes</p>
-                        </div>
-                        <div className="widget-icon-container widget-icon-blue">
-                            <svg className="widget-icon icon-blue" fill="none" stroke="currentColor"
-                                viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                            </svg>
-                        </div>
-                    </div>
-                </div>
+/* ============================================================================
+ * Dashboard
+ * ============================================================================ */
 
-                <div className="widget-card">
-                    <div className="widget-content">
-                        <div>
-                            <p className="widget-info">Volume Lifted</p>
-                            <p className="widget-value">
-                                {isLoading ? "..." : formatNumber(volumeLifted)}
-                            </p>
-                            <p className={`text-sm ${volumeChange.startsWith("+") ? "text-green-600 dark:text-green-400" : "text-red-600 dark:text-red-400"}`}>
-                                {volumeChange} from last week
-                            </p>
-                        </div>
-                        <div className="widget-icon-container widget-icon-green">
-                            <svg className="widget-icon icon-green" fill="none" stroke="currentColor"
-                                viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                    d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"/>
-                            </svg>
-                        </div>
-                    </div>
-                </div>
-            </div>
+interface DashboardProps {
+    /** Mock data fixture. Defaults to activeUserData so the live route renders
+     *  something meaningful before real API wiring lands in a future sprint. */
+    data?: DashboardData;
+}
 
-            {/* Activity Sections */}
-            <div className="activity-sections">
-                <div className="activity-card">
-                    <h3 className="activity-title">Workout Activity</h3>
-                    <p className="activity-description">Your workout frequency and duration over time</p>
-                    <div className="empty-state-container">
-                        <div className="empty-state-icon">
-                            <svg className="empty-state-icon-svg" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                    d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/>
-                            </svg>
-                        </div>
-                        <p className="empty-state-text">No workout data yet</p>
-                        <p className="empty-state-subtext">Add your first workout to see your activity chart</p>
-                        <button className="primary-button">
-                            + Add Workout
-                        </button>
-                    </div>
-                </div>
+export function Dashboard({ data = activeUserData }: DashboardProps) {
+    const { member } = useAuth();
+    const now = new Date();
+    const greeting = getGreeting(now);
+    const firstName = member ? getFirstName(member.name ?? "there") : "there";
+    const date = formatDate(now);
 
-                <div className="activity-card">
-                    <h3 className="activity-title">Weight Trend</h3>
-                    <p className="activity-description">Track your weight progress over time</p>
-                    <div className="empty-state-container">
-                        <div className="empty-state-icon">
-                            <svg className="empty-state-icon-svg" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                    d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3"/>
-                            </svg>
-                        </div>
-                        <p className="empty-state-text">No weight data yet</p>
-                        <p className="empty-state-subtext">Log your weight to track your progress</p>
-                        <button className="secondary-button">
-                            + Log Weight
-                        </button>
-                    </div>
-                </div>
-            </div>
-
-            {/* Goals and Recent Activity */}
-            <div className="goals-section">
-                <div className="goals-card">
-                    <h3 className="activity-title">Weekly Goals</h3>
-                    <p className="activity-description">Your progress toward weekly fitness goals</p>
-                    <div className="goals-grid">
-                        <div className="goal-item">
-                            <div className="goal-circle goal-circle-pink">
-                                <span className="goal-percentage goal-percentage-pink">25%</span>
-                            </div>
-                            <span className="goal-label">Cardio</span>
-                        </div>
-                        <div className="goal-item">
-                            <div className="goal-circle goal-circle-purple">
-                                <span className="goal-percentage goal-percentage-purple">50%</span>
-                            </div>
-                            <span className="goal-label">Strength</span>
-                        </div>
-                        <div className="goal-item">
-                            <div className="goal-circle goal-circle-green">
-                                <span className="goal-percentage goal-percentage-green">80%</span>
-                            </div>
-                            <span className="goal-label">Flexibility</span>
-                        </div>
-                    </div>
-                </div>
-
-                <div className="recent-workouts-card">
-                    <div className="recent-workouts-header">
-                        <h3 className="recent-workouts-title">Recent Workouts</h3>
-                        <button className="view-all-button">
-                            View All
-                        </button>
-                    </div>
-                    <p className="recent-workouts-description">Your latest training sessions</p>
-                    <div className="recent-workouts-empty">
-                        <div className="recent-workouts-empty-icon">
-                            <svg className="empty-state-icon-svg" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-                                    d="M9 6v6m0 0v6m0-6h6m-6 0H9"/>
-                            </svg>
-                        </div>
-                        <p className="recent-workouts-empty-text">No recent workouts</p>
-                    </div>
-                </div>
-            </div>
+    return (
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--spacing-48)" }}>
+            <PageHeader greeting={greeting} name={firstName} date={date} />
+            <QuickStatsSection weekStats={data.weekStats} />
+            <RecentActivitySection activities={data.recentActivities} />
+            {data.insight && <NoticedSection insight={data.insight} />}
         </div>
     );
-};
+}
 
 export default Dashboard;

--- a/fit-track-ui/react/src/pages/dashboard/mock-data.ts
+++ b/fit-track-ui/react/src/pages/dashboard/mock-data.ts
@@ -1,0 +1,128 @@
+/* ============================================================================
+ * Dashboard mock data
+ * ----------------------------------------------------------------------------
+ * All types, fixtures, and formatting helpers for the Dashboard composition.
+ * Dashboard.tsx imports from here; Storybook stories swap the fixture prop.
+ * No backend wiring — this is the sole source of data for FTRACK-21.
+ * ============================================================================ */
+
+export type DashboardData = {
+    weekStats: {
+        sessions: number;
+        sessionsTarget: number;
+        volume: number;           // lbs
+        timeTrainedMinutes: number;
+        volumeDelta: number;      // lbs vs previous week (positive or negative)
+        timeDelta: number;        // minutes vs previous week (positive or negative)
+    };
+    recentActivities: Activity[];
+    insight: Insight | null;      // null = Noticed section omitted entirely
+};
+
+export type Activity = {
+    id: string;
+    type: string;
+    durationMinutes: number;
+    highlight: string;
+    routineContext?: string;       // e.g. "Push Day 1" — omit for Run, Yoga, etc.
+    highlightIsPR: boolean;
+    timestamp: string;            // pre-formatted: "2h ago", "Yesterday", "Mon", "Jun 4"
+};
+
+export type Insight = {
+    eyebrow: string;
+    body: string;
+};
+
+/* ============================================================================
+ * Fixtures
+ * ============================================================================ */
+
+export const activeUserData: DashboardData = {
+    weekStats: {
+        sessions: 3,
+        sessionsTarget: 4,
+        volume: 24300,
+        timeTrainedMinutes: 165,
+        volumeDelta: 1800,
+        timeDelta: 30,
+    },
+    recentActivities: [
+        { id: "a1", type: "Strength", durationMinutes: 52, highlight: "Bench 185×5",    routineContext: "Push Day 1", highlightIsPR: true,  timestamp: "2h ago"    },
+        { id: "a2", type: "Strength", durationMinutes: 48, highlight: "Squat 225×5",    routineContext: "Legs Day 1", highlightIsPR: false, timestamp: "Yesterday" },
+        { id: "a3", type: "Strength", durationMinutes: 65, highlight: "Deadlift 315×3", routineContext: "Pull Day 1", highlightIsPR: true,  timestamp: "Mon"       },
+        { id: "a4", type: "Run",      durationMinutes: 32, highlight: "3.1 mi",                                       highlightIsPR: false, timestamp: "Sun"       },
+        { id: "a5", type: "Strength", durationMinutes: 55, highlight: "Pull 12 sets",   routineContext: "Pull Day 2", highlightIsPR: false, timestamp: "Sat"       },
+    ],
+    insight: {
+        eyebrow: "Noticed",
+        body: "You trained 3 times this week, up from 2 last week.",
+    },
+};
+
+export const lightUserData: DashboardData = {
+    weekStats: {
+        sessions: 1,
+        sessionsTarget: 4,
+        volume: 6200,
+        timeTrainedMinutes: 38,
+        volumeDelta: 6200,
+        timeDelta: 38,
+    },
+    recentActivities: [
+        { id: "b1", type: "Strength", durationMinutes: 38, highlight: "Squat 185×5",            routineContext: "Legs Day 1", highlightIsPR: false, timestamp: "Mon"   },
+        { id: "b2", type: "Strength", durationMinutes: 45, highlight: "First Strength session", routineContext: "Push Day 1", highlightIsPR: false, timestamp: "Jun 1" },
+    ],
+    insight: {
+        eyebrow: "Noticed",
+        body: "Your first full week of training.",
+    },
+};
+
+export const newUserData: DashboardData = {
+    weekStats: {
+        sessions: 0,
+        sessionsTarget: 4,
+        volume: 0,
+        timeTrainedMinutes: 0,
+        volumeDelta: 0,
+        timeDelta: 0,
+    },
+    recentActivities: [],
+    insight: null,
+};
+
+/* ============================================================================
+ * Helpers
+ * ============================================================================ */
+
+export function getGreeting(now: Date): string {
+    const hour = now.getHours();
+    if (hour < 12) return "Good morning";
+    if (hour < 18) return "Good afternoon";
+    return "Good evening";
+}
+
+export function getFirstName(fullName: string): string {
+    return fullName.trim().split(/\s+/)[0];
+}
+
+export function formatDate(date: Date): string {
+    return date.toLocaleDateString("en-US", {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+    });
+}
+
+export function formatVolume(lbs: number): string {
+    return lbs.toLocaleString("en-US");
+}
+
+export function formatDuration(minutes: number): string {
+    if (minutes === 0) return "0m";
+    if (minutes < 60) return `${minutes}m`;
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return mins === 0 ? `${hours}h` : `${hours}h ${mins}m`;
+}


### PR DESCRIPTION
# FTRACK-21: Build Dashboard composition with companion voice

## Description

- Composes `/dashboard` route from FTRACK-35 primitives: PageHeader, MetricCard, ActivityRow, InsightCard
- All data mocked — no backend wiring
- Companion voice rules applied at every section: observations only, no directives
- Three empty-state behaviors: active user, light user, new user

## Changes

**New files:**
- `src/pages/dashboard/Dashboard.tsx` — full replacement of old API-wired component. Four sections: PageHeader (time-of-day greeting + member first name), Quick Stats (3 MetricCards in a grid), Recent Activity (up to 5 compact ActivityRows in a card, dashed placeholder when empty), Noticed (InsightCard, omitted entirely when `insight === null`)
- `src/pages/dashboard/Dashboard.stories.tsx` — ActiveUser / LightUser / NewUser stories with MemoryRouter + MockAuthProvider
- `src/pages/dashboard/mock-data.ts` — `DashboardData` type, 3 fixtures, 5 format helpers (`getGreeting`, `getFirstName`, `formatDate`, `formatVolume`, `formatDuration`)

**Modified primitives (bugs surfaced under composition):**
- `ActivityRow.tsx` — compact variant rebuilt as inline training-log narrative: `type · highlight (routineContext) PR · duration · timestamp`. Added `routineContext?` and `highlightIsPR?` props. Replaced regex dot-color with `TYPE_COLOR_MAP` (Strength → saffron, Run → moss-positive, fallback → pewter). PR badge at 11px saffron. Separator dots: 8px spacing, explicit font sizes. Dots bumped 7px → 8px for color legibility
- `ActivityRow.stories.tsx` — updated to new prop API, added CompactWithContext / CompactWithPR / CompactRun stories
- `SectionTitle.tsx` — action slot now owns indigo-signal / 500 weight / hover → indigo-press styling (callers pass `color: inherit`)
- `tokens.css` — `--color-vellum-surface` deepened `#F2F1ED` → `#EEEDE6` (token contrast fix — was invisible against paper-canvas)
- `Dashboard.tsx` (activity list container) — border changed from `--color-linen-border` to `--color-ash-inset` for visible card edge

## Testing

- Verified at `/dashboard` with activeUserData mock: PageHeader, 3 MetricCards, 5 ActivityRows (4 Strength + 1 Run), InsightCard
- Storybook stories verified: ActiveUser / LightUser / NewUser all render correctly
- NewUser: dashed placeholder visible, Noticed section absent
- `npx tsc --noEmit` — clean
- `npm run lint && npm run lint:css && npm run lint:md` — all clean

## Screenshots

Live dashboard shows inline training narrative per row:
`Strength · Bench 185×5 (Push Day 1) PR · 52m · 2h ago`
Run row shows moss-positive dot vs saffron dots on Strength rows.
InsightCard reads as a distinct surface against paper-canvas.
"View all →" reads as interactive in indigo-signal.

https://github.com/user-attachments/assets/4af410a5-98a8-44a7-ab52-d917d249e73f


## Additional Comments

- MetricCard delta `+` prefix coloring is wired and correct — perceptual issue only (single character at 13px). Future improvement: color full delta phrase
- `→` in "View all →" is Unicode U+2192 — flagged for future Lucide icon swap if rendering inconsistency appears cross-platform

# Checklist

- [x] All tests are passing
- [x] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly