### PR TITLE
FTRACK-39: Customizable workout exercises with editable sets

### DIFF
--- a/Bruno/Fitness Tracker/Refresh Token.bru
+++ b/Bruno/Fitness Tracker/Refresh Token.bru
@@ -16,6 +16,10 @@ body:json {
   }
 }
 
+script:post-response {
+  bru.setEnvVar("bearerToken", res.getBody().accessToken)
+}
+
 settings {
   encodeUrl: true
   timeout: 0

--- a/Bruno/Fitness Tracker/Workout/Add Workout.bru
+++ b/Bruno/Fitness Tracker/Workout/Add Workout.bru
@@ -16,32 +16,54 @@ auth:bearer {
 
 body:json {
   {
-      "customer": {"id":1},
+      "memberId": 1,
       "title": "Upper Body",
       "workoutType": "Strength Training",
+     "volume": 5800,
+      "calories": 122,
+      "durationMinutes": 12,
+      "workoutDate": "2026-06-10T21:45:13.018-05:00",
       "exercises": [
         {
           "title": "Incline Dumbbell Press",
           "equipment": "Dumbbell",
           "description": "Incline dumbbell press targeting upper chest",
           "muscleGroup": "Chest",
-          "reps": 10,
-          "sets": 2,
-          "weightPerRep": 70
+          "concentration": "Chest",
+          "isBilateral": true,
+          "sets": [
+            {
+              "setNumber": 1,
+              "reps": 10,
+              "weight": 70
+            },
+             {
+              "setNumber": 2,
+              "reps": 10,
+              "weight": 70
+            }
+          ]
         },
         {
           "title": "Push-ups",
           "equipment": "Bodyweight",
           "description": "Bodyweight exercise for chest, shoulders, and triceps",
           "muscleGroup": "Chest",
-          "reps": 15,
-          "sets": 2,
-          "weightPerRep": 70
+          "concentration": "Chest",
+          "isBilateral": false,
+          "sets": [
+              {
+                "setNumber": 1,
+                "reps": 15,
+                "weight": 175
+              },
+               {
+                "setNumber": 2,
+                "reps": 15,
+                "weight": 175
+              }
+          ]
         }
-      ],
-      "volume": 2800,
-      "calories": 44,
-      "durationMinutes": 8,
-      "workoutDate": "2026-02-03T21:45:13.018-05:00"
+      ]
     }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/exercise/ExerciseEntity.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/exercise/ExerciseEntity.java
@@ -1,9 +1,12 @@
 package com.robinsonir.fittrack.data.entity.exercise;
 
 import com.robinsonir.fittrack.data.entity.AbstractEntity;
+import com.robinsonir.fittrack.data.entity.set.SetEntity;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+
+import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -22,15 +25,13 @@ public class ExerciseEntity extends AbstractEntity {
     @Column(name = "muscle_group", nullable = false)
     private String muscleGroup;
 
-    @Column(name = "sets", nullable = false)
-    private Integer sets;
-
-    @Column(name = "reps", nullable = false)
-    private Integer reps;
-
-    @Column(name = "weight_per_rep", nullable = false)
-    private Integer weightPerRep;
-
     @Column(name = "concentration", nullable = false)
     private String concentration;
+
+    @Column(name = "is_bilateral", nullable = false)
+    private Boolean isBilateral;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "exercise_id")
+    private List<SetEntity> sets;
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/set/SetEntity.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/set/SetEntity.java
@@ -1,0 +1,24 @@
+package com.robinsonir.fittrack.data.entity.set;
+
+import com.robinsonir.fittrack.data.entity.AbstractEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(schema = "fit_tracker", name = "sets")
+public class SetEntity extends AbstractEntity {
+
+    @Column(name = "set_number")
+    private Integer setNumber;
+
+    @Column(name = "reps")
+    private Integer reps;
+
+    @Column(name = "weight")
+    private Integer weight;
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/exercise/ExerciseDTO.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/exercise/ExerciseDTO.java
@@ -1,8 +1,11 @@
 package com.robinsonir.fittrack.data.repository.exercise;
 
+import com.robinsonir.fittrack.data.repository.set.SetDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema
+import java.util.List;
+
+@Schema(name = "ExerciseDTO")
 public record ExerciseDTO(
         Long id,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
@@ -16,10 +19,7 @@ public record ExerciseDTO(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String concentration,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Integer reps,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Integer sets,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Integer weightPerRep
+        Boolean isBilateral,
+        List<SetDTO> sets
 ){
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/set/SetDTO.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/set/SetDTO.java
@@ -1,0 +1,16 @@
+package com.robinsonir.fittrack.data.repository.set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "SetDTO")
+public record SetDTO(
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Long id,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer setNumber,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer reps,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer weight
+) {
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/workout/WorkoutCreationRequest.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/workout/WorkoutCreationRequest.java
@@ -11,14 +11,16 @@ public record WorkoutCreationRequest(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String title,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Set<ExerciseDTO> exercises,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String workoutType,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Integer volume,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Integer calories,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Integer durationMinutes
+        Integer durationMinutes,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean isBilateral,
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        Set<ExerciseDTO> exercises
 ) {
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/workout/WorkoutCreationRequest.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/workout/WorkoutCreationRequest.java
@@ -19,8 +19,6 @@ public record WorkoutCreationRequest(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Integer durationMinutes,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
-        Boolean isBilateral,
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Set<ExerciseDTO> exercises
 ) {
 }

--- a/fit-track/src/main/resources/db/migration/V202606131443__fit-track_add_sets_table.sql
+++ b/fit-track/src/main/resources/db/migration/V202606131443__fit-track_add_sets_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS fit_tracker.sets (
+    id SERIAL PRIMARY KEY,
+    version INTEGER NOT NULL,
+    set_number INTEGER NOT NULL,
+    reps INTEGER NOT NULL,
+    weight INTEGER NOT NULL,
+    exercise_id INTEGER REFERENCES fit_tracker.exercises(id)
+);
+
+ALTER TABLE fit_tracker.exercises
+    ADD COLUMN IF NOT EXISTS is_bilateral BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE fit_tracker.exercises
+    DROP COLUMN IF EXISTS sets;
+
+ALTER TABLE fit_tracker.exercises
+    DROP COLUMN IF EXISTS reps;
+
+ALTER TABLE fit_tracker.exercises
+    DROP COLUMN IF EXISTS weight_per_rep;

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
@@ -126,7 +126,7 @@ public class WorkoutServiceTest {
     void addWorkout() {
         // Arrange
         WorkoutCreationRequest workoutCreationRequest = new WorkoutCreationRequest(
-                member.getId(), "Swimming", new HashSet<>(), "Cardio", 12000, 400, 60
+                member.getId(), "Swimming", "Cardio", 12000, 400, 60, false, new HashSet<>()
         );
 
         when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
@@ -126,7 +126,7 @@ public class WorkoutServiceTest {
     void addWorkout() {
         // Arrange
         WorkoutCreationRequest workoutCreationRequest = new WorkoutCreationRequest(
-                member.getId(), "Swimming", "Cardio", 12000, 400, 60, false, new HashSet<>()
+                member.getId(), "Swimming", "Cardio", 12000, 400, 60, new HashSet<>()
         );
 
         when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));


### PR DESCRIPTION
# FTRACK-39: Customizable workout exercises with editable sets

## Description

- Replaces the flat exercise structure (`sets`, `reps`, `weightPerRep`) with a per-set model where each exercise has a list of individual sets, each with its own `setNumber`, `reps`, and `weight`.
- Adds `isBilateral` flag to exercises to support future volume calculation for bilateral movements.

## Changes

- **New `SetEntity` + `SetDTO`**: Introduced `fit_tracker.sets` table and corresponding entity/DTO with `setNumber`, `reps`, `weight`.
- **Updated `ExerciseEntity`**: Removed flat `sets`, `reps`, `weightPerRep` columns. Added `isBilateral` (Boolean) and `@OneToMany` relationship to `SetEntity`.
- **Updated `ExerciseDTO`**: Mirrors entity changes — replaced flat fields with `isBilateral` and `List<SetDTO>`.
- **Updated `WorkoutCreationRequest`**: Reordered fields, added `isBilateral`, moved `exercises` to last position.
- **Flyway migration** (`V202606131443`): Creates `sets` table, adds `is_bilateral` column to `exercises`, drops old `sets`/`reps`/`weight_per_rep` columns.
- **Bruno API collection**: Updated `Add Workout` request body to match new structure; added post-response script to `Refresh Token` for auto-setting bearer token.
- **Test fix**: Updated `WorkoutServiceTest.addWorkout()` to match new `WorkoutCreationRequest` constructor.

## Testing

- **Old behavior**: Exercises had flat `sets: 2, reps: 10, weightPerRep: 70` — assumed uniform sets.
- **New behavior**: Exercises have a list of sets, each with independent `reps` and `weight` values, supporting pyramid sets, drop sets, warm-up sets, etc.
- All existing tests pass (`./gradlew test` — BUILD SUCCESSFUL).

## Screenshots

- N/A (backend-only changes)

## Additional Comments

- This unblocks FTRACK-40 (Unified Activity API) which depends on the new exercise/set structure for deriving highlights and volume.
- Volume is no longer stored — it will be derived from `sum(reps × weight)` across sets in a future service change.

# Checklist

- [x] All tests are passing
- [x] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly