### PR TITLE
FTRACK-40: Unified Activity API — summary list + polymorphic detail endpoint

### DIFF
--- a/Bruno/Fitness Tracker/Activities/Get Activity Detail.bru
+++ b/Bruno/Fitness Tracker/Activities/Get Activity Detail.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Get Activity Detail
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}:8080/api/v1/activities/:activityId
+  body: none
+  auth: bearer
+}
+
+params:path {
+  activityId: 1
+}
+
+auth:bearer {
+  token: {{bearerToken}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/Bruno/Fitness Tracker/Activities/Get Summary Activities By Member ID.bru
+++ b/Bruno/Fitness Tracker/Activities/Get Summary Activities By Member ID.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Get Summary Activities By Member ID
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{baseUrl}}:8080/api/v1/activities/member/:memberId
+  body: none
+  auth: bearer
+}
+
+params:query {
+  ~activityType: 
+}
+
+params:path {
+  memberId: 1
+}
+
+auth:bearer {
+  token: {{bearerToken}}
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/Bruno/Fitness Tracker/Activities/folder.bru
+++ b/Bruno/Fitness Tracker/Activities/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Activities
+  seq: 6
+}
+
+auth {
+  mode: inherit
+}

--- a/Bruno/Fitness Tracker/Audit/folder.bru
+++ b/Bruno/Fitness Tracker/Audit/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Audit
+  seq: 3
+}

--- a/Bruno/Fitness Tracker/Member/folder.bru
+++ b/Bruno/Fitness Tracker/Member/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Member
+  seq: 4
+}

--- a/Bruno/Fitness Tracker/Workout/folder.bru
+++ b/Bruno/Fitness Tracker/Workout/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Workout
+  seq: 6
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/api/ActivitiesController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/api/ActivitiesController.java
@@ -1,0 +1,27 @@
+package com.robinsonir.fittrack.api;
+
+import com.robinsonir.fittrack.data.repository.activities.ActivitySummaryDTO;
+import com.robinsonir.fittrack.data.service.activities.ActivitiesService;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@Tag(name = "Activities API", description = "API for managing activities")
+@RequestMapping(path = "api/v1/activities")
+public class ActivitiesController {
+    private final ActivitiesService activitiesService;
+
+    public ActivitiesController(final ActivitiesService activitiesService) {
+        this.activitiesService = activitiesService;
+    }
+
+    @GetMapping("/member/{memberId}")
+    public List<ActivitySummaryDTO> getMemberActivitiesByActivityType(
+            @Parameter(description = "memberId", required = true) @PathVariable final Long memberId,
+            @RequestParam(required = false) final String activityType) {
+        return activitiesService.getMemberActivitiesByActivityType(memberId, activityType);
+    }
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/api/ActivitiesController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/api/ActivitiesController.java
@@ -1,8 +1,10 @@
 package com.robinsonir.fittrack.api;
 
+import com.robinsonir.fittrack.data.repository.activities.ActivityDetailDTO;
 import com.robinsonir.fittrack.data.repository.activities.ActivitySummaryDTO;
 import com.robinsonir.fittrack.data.service.activities.ActivitiesService;
-import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,10 +20,17 @@ public class ActivitiesController {
         this.activitiesService = activitiesService;
     }
 
+    @Operation(summary = "Get Summary activities by MemberId and or Activity Type")
     @GetMapping("/member/{memberId}")
     public List<ActivitySummaryDTO> getMemberActivitiesByActivityType(
-            @Parameter(description = "memberId", required = true) @PathVariable final Long memberId,
-            @RequestParam(required = false) final String activityType) {
+            @PathVariable final Long memberId, @RequestParam(required = false) final String activityType) {
         return activitiesService.getMemberActivitiesByActivityType(memberId, activityType);
+    }
+
+    @Operation(summary = "Get an activity detail by ID")
+    @ApiResponse(responseCode = "404", description = "Activity not found")
+    @GetMapping("/{activityId}")
+    public ActivityDetailDTO getActivityDetail(@PathVariable final Long activityId) {
+        return activitiesService.getActivityDetail(activityId);
     }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/api/WorkoutController.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/api/WorkoutController.java
@@ -1,6 +1,6 @@
 package com.robinsonir.fittrack.api;
 
-import com.robinsonir.fittrack.data.repository.workout.WorkoutDTO;
+import com.robinsonir.fittrack.data.repository.activities.WorkoutDTO;
 import com.robinsonir.fittrack.data.service.workout.WorkoutCreationRequest;
 import com.robinsonir.fittrack.data.service.workout.WorkoutService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/activities/ActivityEntity.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/entity/activities/ActivityEntity.java
@@ -1,0 +1,40 @@
+package com.robinsonir.fittrack.data.entity.activities;
+
+import com.robinsonir.fittrack.data.entity.AbstractEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.OffsetDateTime;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@Entity
+@Table(schema = "fit_tracker", name = "activities")
+public class ActivityEntity extends AbstractEntity {
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "source_id")
+    private Long sourceId;
+
+    @Column(name = "activity_type")
+    private String activityType;
+
+    @Column(name = "routine_context")
+    private String routineContext;
+
+    @Column(name = "duration_minutes")
+    private Integer durationMinutes;
+
+    @Column(name = "highlight")
+    private String highlight;
+
+    @Column(name = "highlight_is_pr")
+    private Boolean highlightIsPR;
+
+    @Column(name = "activity_timestamp")
+    private OffsetDateTime activityTimestamp;
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/ActivityDetailDTO.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/ActivityDetailDTO.java
@@ -1,0 +1,21 @@
+package com.robinsonir.fittrack.data.repository.activities;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.time.OffsetDateTime;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
+        property = "activityType")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value =
+                WorkoutDTO.class, name = "Workout")
+})
+public sealed interface ActivityDetailDTO permits WorkoutDTO {
+    Long id();
+    String activityType();
+    Long memberId();
+    String routineContext();
+    Integer durationMinutes();
+    OffsetDateTime activityTimestamp();
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/ActivityDetailDTO.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/ActivityDetailDTO.java
@@ -2,6 +2,7 @@ package com.robinsonir.fittrack.data.repository.activities;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.OffsetDateTime;
 
@@ -11,11 +12,17 @@ import java.time.OffsetDateTime;
         @JsonSubTypes.Type(value =
                 WorkoutDTO.class, name = "Workout")
 })
+@Schema(name = "ActivityDetailDTO")
 public sealed interface ActivityDetailDTO permits WorkoutDTO {
     Long id();
+
     String activityType();
+
     Long memberId();
+
     String routineContext();
+
     Integer durationMinutes();
+
     OffsetDateTime activityTimestamp();
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/ActivityRepository.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/ActivityRepository.java
@@ -1,0 +1,13 @@
+package com.robinsonir.fittrack.data.repository.activities;
+
+import com.robinsonir.fittrack.data.entity.activities.ActivityEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ActivityRepository extends JpaRepository<ActivityEntity, Long> {
+
+    List<ActivityEntity> findByMemberIdAndActivityType(Long memberId, String activityType);
+
+    List<ActivityEntity> findByMemberId(Long memberId);
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/ActivitySummaryDTO.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/ActivitySummaryDTO.java
@@ -1,0 +1,16 @@
+package com.robinsonir.fittrack.data.repository.activities;
+
+import java.time.OffsetDateTime;
+
+public record ActivitySummaryDTO(
+        Long id,
+        Long memberId,
+        Long sourceId,
+        String activityType,
+        String routineContext,
+        Integer durationMinutes,
+        String highlight,
+        Boolean highlightIsPR,
+        OffsetDateTime activityTimestamp
+) {
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/WorkoutDTO.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/WorkoutDTO.java
@@ -26,19 +26,18 @@ public record WorkoutDTO(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         OffsetDateTime workoutDate
 ) implements ActivityDetailDTO {
-        @Override
-        public String activityType() {
-                return "Workout";
-        }
+    @Override
+    public String activityType() {
+        return "Workout";
+    }
 
-        @Override
-        public OffsetDateTime activityTimestamp()
-        {
-                return workoutDate;
-        }
+    @Override
+    public OffsetDateTime activityTimestamp() {
+        return workoutDate;
+    }
 
-        @Override
-        public String routineContext() {
-                return title;
-        }
+    @Override
+    public String routineContext() {
+        return title;
+    }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/WorkoutDTO.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/repository/activities/WorkoutDTO.java
@@ -1,4 +1,4 @@
-package com.robinsonir.fittrack.data.repository.workout;
+package com.robinsonir.fittrack.data.repository.activities;
 
 import com.robinsonir.fittrack.data.repository.exercise.ExerciseDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,5 +25,20 @@ public record WorkoutDTO(
         Integer durationMinutes,
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         OffsetDateTime workoutDate
-) {
+) implements ActivityDetailDTO {
+        @Override
+        public String activityType() {
+                return "Workout";
+        }
+
+        @Override
+        public OffsetDateTime activityTimestamp()
+        {
+                return workoutDate;
+        }
+
+        @Override
+        public String routineContext() {
+                return title;
+        }
 }

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/activities/ActivitiesService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/activities/ActivitiesService.java
@@ -1,0 +1,73 @@
+package com.robinsonir.fittrack.data.service.activities;
+
+import com.robinsonir.fittrack.data.entity.activities.ActivityEntity;
+import com.robinsonir.fittrack.data.entity.exercise.ExerciseEntity;
+import com.robinsonir.fittrack.data.entity.set.SetEntity;
+import com.robinsonir.fittrack.data.entity.workout.WorkoutEntity;
+import com.robinsonir.fittrack.data.repository.activities.ActivityDetailDTO;
+import com.robinsonir.fittrack.data.repository.activities.ActivityRepository;
+import com.robinsonir.fittrack.data.repository.activities.ActivitySummaryDTO;
+import com.robinsonir.fittrack.data.service.workout.WorkoutService;
+import com.robinsonir.fittrack.exception.ResourceNotFoundException;
+import com.robinsonir.fittrack.mappers.ActivityMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ActivitiesService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActivitiesService.class);
+    private final WorkoutService workoutService;
+    private final ActivityRepository activityRepository;
+    private final ActivityMapper activityMapper;
+
+    public ActivitiesService(final WorkoutService workoutService,
+                             final ActivityMapper activityMapper, final ActivityRepository activityRepository) {
+        this.workoutService = workoutService;
+        this.activityMapper = activityMapper;
+        this.activityRepository = activityRepository;
+    }
+
+    public List<ActivitySummaryDTO> getMemberActivitiesByActivityType(Long memberId, String activityType) {
+        LOGGER.info("Getting activities for member {} with activity type {}", memberId, activityType);
+        if (activityType != null) {
+            return activityMapper.activityEntityListToActivitySummaryDTOList(activityRepository.findByMemberIdAndActivityType(memberId, activityType));
+        } else {
+            return activityMapper.activityEntityListToActivitySummaryDTOList(activityRepository.findByMemberId(memberId));
+        }
+    }
+
+    public ActivityDetailDTO getActivityDetail(Long activityId) {
+        LOGGER.info("Getting activity detail for activity {}", activityId);
+        ActivityEntity activity = activityRepository.findById(activityId)
+                .orElseThrow(() -> new ResourceNotFoundException("Activity not found"));
+
+        return switch (activity.getActivityType())
+        {
+            case "Workout" -> workoutService.getWorkout(activity.getSourceId());
+            default -> throw new IllegalStateException("Unexpected value: " + activity.getActivityType());
+        };
+    }
+
+    public void addActivity(ActivityEntity activity) {
+        LOGGER.info("Adding activity {}", activity);
+        activityRepository.save(activity);
+    }
+
+    public String getHighlight(WorkoutEntity workout) {
+        String highlight = "";
+        Integer weight = 0;
+        for (ExerciseEntity exercise : workout.getExercises()) {
+            for (SetEntity set : exercise.getSets()) {
+                if (set.getWeight() > weight) {
+                    weight = set.getWeight();
+                    highlight = exercise.getTitle() + " " + set.getWeight() + "x" + set.getReps();
+                }
+            }
+        }
+        return highlight;
+    }
+
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/data/service/workout/WorkoutService.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/data/service/workout/WorkoutService.java
@@ -1,18 +1,21 @@
 package com.robinsonir.fittrack.data.service.workout;
 
+import com.robinsonir.fittrack.data.entity.activities.ActivityEntity;
 import com.robinsonir.fittrack.data.entity.exercise.ExerciseEntity;
 import com.robinsonir.fittrack.data.entity.member.MemberEntity;
 import com.robinsonir.fittrack.data.entity.set.SetEntity;
 import com.robinsonir.fittrack.data.entity.workout.WorkoutEntity;
 import com.robinsonir.fittrack.data.repository.member.MemberRepository;
-import com.robinsonir.fittrack.data.repository.workout.WorkoutDTO;
+import com.robinsonir.fittrack.data.repository.activities.WorkoutDTO;
 import com.robinsonir.fittrack.data.repository.workout.WorkoutRepository;
+import com.robinsonir.fittrack.data.service.activities.ActivitiesService;
 import com.robinsonir.fittrack.exception.ResourceNotFoundException;
 import com.robinsonir.fittrack.mappers.ExerciseMapper;
 import com.robinsonir.fittrack.mappers.WorkoutMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
@@ -30,16 +33,19 @@ public class WorkoutService {
     private final ExerciseMapper exerciseMapper;
     private final WorkoutRepository workoutRepository;
     private final MemberRepository memberRepository;
+    private final ActivitiesService activitiesService;
 
     @Autowired
     public WorkoutService(final WorkoutMapper workoutMapper,
                           final WorkoutRepository workoutRepository,
                           final ExerciseMapper exerciseMapper,
-                          final MemberRepository memberRepository) {
+                          final MemberRepository memberRepository,
+                          @Lazy final ActivitiesService activitiesService) {
         this.workoutMapper = workoutMapper;
         this.workoutRepository = workoutRepository;
         this.memberRepository = memberRepository;
         this.exerciseMapper = exerciseMapper;
+        this.activitiesService = activitiesService;
     }
 
 
@@ -65,6 +71,7 @@ public class WorkoutService {
         Optional<MemberEntity> memberEntity = memberRepository.findById(workoutCreationRequest.memberId());
 
         WorkoutEntity newWorkout = new WorkoutEntity();
+        ActivityEntity activity = new ActivityEntity();
         if (memberEntity.isPresent()) {
             newWorkout.setWorkoutType(workoutCreationRequest.workoutType());
             newWorkout.setTitle(workoutCreationRequest.title());
@@ -73,12 +80,24 @@ public class WorkoutService {
             newWorkout.setWorkoutDate(OffsetDateTime.now());
             newWorkout.setVolume(calculateVolume(newWorkout.getExercises()));
             newWorkout.setCalories(calculateCalories(memberEntity.get().getWeight(), newWorkout.getDurationMinutes()));
-        }
 
-        memberEntity.ifPresent(newWorkout::setMember);
-        workoutRepository.save(newWorkout);
-        LOGGER.info("Workout created successfully");
-        return workoutMapper.convertWorkoutEntityToWorkout(newWorkout);
+            activity.setActivityTimestamp(newWorkout.getWorkoutDate());
+            activity.setActivityType("Workout");
+            activity.setMemberId(memberEntity.get().getId());
+            activity.setRoutineContext(newWorkout.getTitle());
+            activity.setDurationMinutes(newWorkout.getDurationMinutes());
+            activity.setHighlight(activitiesService.getHighlight(newWorkout));
+            activity.setHighlightIsPR(false);
+
+            newWorkout.setMember(memberEntity.get());
+
+            workoutRepository.save(newWorkout);
+            activity.setSourceId(newWorkout.getId());
+            activitiesService.addActivity(activity);
+            LOGGER.info("Workout created successfully");
+            return workoutMapper.convertWorkoutEntityToWorkout(newWorkout);
+        }
+        return null;
     }
 
     public void checkIfWorkoutExistsOrThrow(Long id) {

--- a/fit-track/src/main/java/com/robinsonir/fittrack/mappers/ActivityMapper.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/mappers/ActivityMapper.java
@@ -1,0 +1,14 @@
+package com.robinsonir.fittrack.mappers;
+
+import com.robinsonir.fittrack.data.entity.activities.ActivityEntity;
+import com.robinsonir.fittrack.data.repository.activities.ActivitySummaryDTO;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(config = FitTrackMapperConfig.class)
+public interface ActivityMapper {
+    ActivitySummaryDTO activityEntityToActivitySummaryDTO(ActivityEntity activityEntity);
+
+    List<ActivitySummaryDTO> activityEntityListToActivitySummaryDTOList(List<ActivityEntity> activityEntities);
+}

--- a/fit-track/src/main/java/com/robinsonir/fittrack/mappers/WorkoutMapper.java
+++ b/fit-track/src/main/java/com/robinsonir/fittrack/mappers/WorkoutMapper.java
@@ -1,7 +1,7 @@
 package com.robinsonir.fittrack.mappers;
 
 import com.robinsonir.fittrack.data.entity.workout.WorkoutEntity;
-import com.robinsonir.fittrack.data.repository.workout.WorkoutDTO;
+import com.robinsonir.fittrack.data.repository.activities.WorkoutDTO;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 

--- a/fit-track/src/main/resources/db/migration/V202606152038__fit_track_add_activities_table.sql
+++ b/fit-track/src/main/resources/db/migration/V202606152038__fit_track_add_activities_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS fit_tracker.activities (
+    id SERIAL PRIMARY KEY,
+    version INTEGER NOT NULL,
+    activity_type VARCHAR(255) NOT NULL,
+    routine_context VARCHAR(255),
+    duration_minutes INTEGER NOT NULL,
+    highlight VARCHAR(255) NOT NULL,
+    highlight_is_pr BOOLEAN NOT NULL,
+    activity_timestamp TIMESTAMP NOT NULL,
+    source_id INTEGER NOT NULL,
+    member_id INTEGER REFERENCES fit_tracker.member(id)
+)

--- a/fit-track/src/test/java/com/robinsonir/fittrack/api/ActivitiesControllerTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/api/ActivitiesControllerTest.java
@@ -1,0 +1,114 @@
+package com.robinsonir.fittrack.api;
+
+import com.robinsonir.fittrack.data.repository.activities.ActivityDetailDTO;
+import com.robinsonir.fittrack.data.repository.activities.ActivitySummaryDTO;
+import com.robinsonir.fittrack.data.repository.activities.WorkoutDTO;
+import com.robinsonir.fittrack.data.service.activities.ActivitiesService;
+import com.robinsonir.fittrack.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ActivitiesControllerTest {
+
+    @Mock
+    private ActivitiesService activitiesService;
+
+    @InjectMocks
+    private ActivitiesController activitiesController;
+
+    @Test
+    void getMemberActivitiesWithoutActivityType() {
+        // Arrange
+        Long memberId = 1L;
+        ActivitySummaryDTO summary = new ActivitySummaryDTO(1L, memberId, 10L, "Workout",
+                "Push Day", 60, "Bench Press 225x5", false, OffsetDateTime.now());
+
+        when(activitiesService.getMemberActivitiesByActivityType(memberId, null))
+                .thenReturn(List.of(summary));
+
+        // Act
+        List<ActivitySummaryDTO> result = activitiesController.getMemberActivitiesByActivityType(memberId, null);
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals(summary, result.get(0));
+        verify(activitiesService, times(1)).getMemberActivitiesByActivityType(memberId, null);
+    }
+
+    @Test
+    void getMemberActivitiesWithActivityType() {
+        // Arrange
+        Long memberId = 1L;
+        String activityType = "Workout";
+        ActivitySummaryDTO summary = new ActivitySummaryDTO(1L, memberId, 10L, activityType,
+                "Leg Day", 63, "Squat 275x5", false, OffsetDateTime.now());
+
+        when(activitiesService.getMemberActivitiesByActivityType(memberId, activityType))
+                .thenReturn(List.of(summary));
+
+        // Act
+        List<ActivitySummaryDTO> result = activitiesController.getMemberActivitiesByActivityType(memberId, activityType);
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals("Workout", result.get(0).activityType());
+        verify(activitiesService, times(1)).getMemberActivitiesByActivityType(memberId, activityType);
+    }
+
+    @Test
+    void getMemberActivitiesReturnsEmptyList() {
+        // Arrange
+        Long memberId = 99L;
+        when(activitiesService.getMemberActivitiesByActivityType(memberId, null))
+                .thenReturn(List.of());
+
+        // Act
+        List<ActivitySummaryDTO> result = activitiesController.getMemberActivitiesByActivityType(memberId, null);
+
+        // Assert
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void getActivityDetailReturnsWorkoutDTO() {
+        // Arrange
+        Long activityId = 1L;
+        WorkoutDTO workoutDTO = new WorkoutDTO(10L, 1L, "Push Day", "Push",
+                new HashSet<>(), 5000, 300, 60, OffsetDateTime.now());
+
+        when(activitiesService.getActivityDetail(activityId)).thenReturn(workoutDTO);
+
+        // Act
+        ActivityDetailDTO result = activitiesController.getActivityDetail(activityId);
+
+        // Assert
+        assertNotNull(result);
+        assertInstanceOf(WorkoutDTO.class, result);
+        assertEquals("Workout", result.activityType());
+        assertEquals(10L, result.id());
+        verify(activitiesService, times(1)).getActivityDetail(activityId);
+    }
+
+    @Test
+    void getActivityDetailThrowsWhenNotFound() {
+        // Arrange
+        Long activityId = 99L;
+        when(activitiesService.getActivityDetail(activityId))
+                .thenThrow(new ResourceNotFoundException("Activity not found"));
+
+        // Act and Assert
+        assertThrows(ResourceNotFoundException.class,
+                () -> activitiesController.getActivityDetail(activityId));
+    }
+}

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/repository/activities/ActivityRepositoryTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/repository/activities/ActivityRepositoryTest.java
@@ -1,0 +1,106 @@
+package com.robinsonir.fittrack.data.repository.activities;
+
+import com.robinsonir.fittrack.data.Gender;
+import com.robinsonir.fittrack.data.entity.activities.ActivityEntity;
+import com.robinsonir.fittrack.data.entity.member.MemberEntity;
+import com.robinsonir.fittrack.data.repository.member.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+public class ActivityRepositoryTest {
+
+    @Autowired
+    private ActivityRepository activityRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private MemberEntity member;
+
+    @BeforeEach
+    void setUp() {
+        member = new MemberEntity();
+        member.setName("John Doe");
+        member.setEmail("john.doe@example.com");
+        member.setPassword("password123");
+        member.setDateOfBirth(LocalDate.of(1995, 1, 1));
+        member.setGender(Gender.MALE);
+        memberRepository.save(member);
+    }
+
+    @Test
+    void testSaveActivity() {
+        ActivityEntity activity = createActivity(member.getId(), "Workout", 1L);
+
+        ActivityEntity saved = activityRepository.save(activity);
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getActivityType()).isEqualTo("Workout");
+        assertThat(saved.getMemberId()).isEqualTo(member.getId());
+        assertThat(saved.getSourceId()).isEqualTo(1L);
+    }
+
+    @Test
+    void testFindByMemberId() {
+        activityRepository.save(createActivity(member.getId(), "Workout", 1L));
+        activityRepository.save(createActivity(member.getId(), "Workout", 2L));
+
+        List<ActivityEntity> results = activityRepository.findByMemberId(member.getId());
+
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    void testFindByMemberIdReturnsEmptyForUnknownMember() {
+        activityRepository.save(createActivity(member.getId(), "Workout", 1L));
+
+        List<ActivityEntity> results = activityRepository.findByMemberId(999L);
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void testFindByMemberIdAndActivityType() {
+        activityRepository.save(createActivity(member.getId(), "Workout", 1L));
+        activityRepository.save(createActivity(member.getId(), "Workout", 2L));
+        activityRepository.save(createActivity(member.getId(), "Run", 3L));
+
+        List<ActivityEntity> workouts = activityRepository.findByMemberIdAndActivityType(member.getId(), "Workout");
+        List<ActivityEntity> runs = activityRepository.findByMemberIdAndActivityType(member.getId(), "Run");
+
+        assertThat(workouts).hasSize(2);
+        assertThat(runs).hasSize(1);
+        assertThat(runs.get(0).getSourceId()).isEqualTo(3L);
+    }
+
+    @Test
+    void testFindByMemberIdAndActivityTypeReturnsEmptyForNoMatch() {
+        activityRepository.save(createActivity(member.getId(), "Workout", 1L));
+
+        List<ActivityEntity> results = activityRepository.findByMemberIdAndActivityType(member.getId(), "Run");
+
+        assertThat(results).isEmpty();
+    }
+
+    private ActivityEntity createActivity(Long memberId, String activityType, Long sourceId) {
+        ActivityEntity entity = new ActivityEntity();
+        entity.setMemberId(memberId);
+        entity.setSourceId(sourceId);
+        entity.setActivityType(activityType);
+        entity.setRoutineContext("Push Day");
+        entity.setDurationMinutes(60);
+        entity.setHighlight("Bench Press 225x5");
+        entity.setHighlightIsPR(false);
+        entity.setActivityTimestamp(OffsetDateTime.now());
+        return entity;
+    }
+}

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/service/activities/ActivitiesServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/service/activities/ActivitiesServiceTest.java
@@ -1,0 +1,215 @@
+package com.robinsonir.fittrack.data.service.activities;
+
+import com.robinsonir.fittrack.data.entity.activities.ActivityEntity;
+import com.robinsonir.fittrack.data.repository.activities.ActivityDetailDTO;
+import com.robinsonir.fittrack.data.repository.activities.ActivityRepository;
+import com.robinsonir.fittrack.data.repository.activities.ActivitySummaryDTO;
+import com.robinsonir.fittrack.data.repository.activities.WorkoutDTO;
+import com.robinsonir.fittrack.data.entity.exercise.ExerciseEntity;
+import com.robinsonir.fittrack.data.entity.set.SetEntity;
+import com.robinsonir.fittrack.data.entity.workout.WorkoutEntity;
+import com.robinsonir.fittrack.data.service.workout.WorkoutService;
+import com.robinsonir.fittrack.exception.ResourceNotFoundException;
+import com.robinsonir.fittrack.mappers.ActivityMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ActivitiesServiceTest {
+
+    @Mock
+    private WorkoutService workoutService;
+
+    @Mock
+    private ActivityRepository activityRepository;
+
+    @Mock
+    private ActivityMapper activityMapper;
+
+    @InjectMocks
+    private ActivitiesService activitiesService;
+
+    @Test
+    void getMemberActivitiesWithActivityType() {
+        // Arrange
+        Long memberId = 1L;
+        String activityType = "Workout";
+        ActivityEntity entity = createActivityEntity(memberId, activityType);
+        List<ActivityEntity> entities = List.of(entity);
+        ActivitySummaryDTO summaryDTO = createSummaryDTO(memberId, activityType);
+
+        when(activityRepository.findByMemberIdAndActivityType(memberId, activityType)).thenReturn(entities);
+        when(activityMapper.activityEntityListToActivitySummaryDTOList(entities)).thenReturn(List.of(summaryDTO));
+
+        // Act
+        List<ActivitySummaryDTO> result = activitiesService.getMemberActivitiesByActivityType(memberId, activityType);
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals(summaryDTO, result.get(0));
+        verify(activityRepository, times(1)).findByMemberIdAndActivityType(memberId, activityType);
+        verify(activityRepository, never()).findByMemberId(memberId);
+    }
+
+    @Test
+    void getMemberActivitiesWithoutActivityType() {
+        // Arrange
+        Long memberId = 1L;
+        ActivityEntity entity = createActivityEntity(memberId, "Workout");
+        List<ActivityEntity> entities = List.of(entity);
+        ActivitySummaryDTO summaryDTO = createSummaryDTO(memberId, "Workout");
+
+        when(activityRepository.findByMemberId(memberId)).thenReturn(entities);
+        when(activityMapper.activityEntityListToActivitySummaryDTOList(entities)).thenReturn(List.of(summaryDTO));
+
+        // Act
+        List<ActivitySummaryDTO> result = activitiesService.getMemberActivitiesByActivityType(memberId, null);
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals(summaryDTO, result.get(0));
+        verify(activityRepository, never()).findByMemberIdAndActivityType(anyLong(), anyString());
+        verify(activityRepository, times(1)).findByMemberId(memberId);
+    }
+
+    @Test
+    void getActivityDetailForWorkout() {
+        // Arrange
+        Long activityId = 1L;
+        Long sourceId = 10L;
+        ActivityEntity entity = createActivityEntity(1L, "Workout");
+        entity.setId(activityId);
+        entity.setSourceId(sourceId);
+
+        WorkoutDTO workoutDTO = new WorkoutDTO(sourceId, 1L, "Push Day", "Push",
+                new HashSet<>(), 5000, 300, 60, OffsetDateTime.now());
+
+        when(activityRepository.findById(activityId)).thenReturn(Optional.of(entity));
+        when(workoutService.getWorkout(sourceId)).thenReturn(workoutDTO);
+
+        // Act
+        ActivityDetailDTO result = activitiesService.getActivityDetail(activityId);
+
+        // Assert
+        assertNotNull(result);
+        assertInstanceOf(WorkoutDTO.class, result);
+        assertEquals("Workout", result.activityType());
+        verify(activityRepository, times(1)).findById(activityId);
+        verify(workoutService, times(1)).getWorkout(sourceId);
+    }
+
+    @Test
+    void getActivityDetailThrowsWhenNotFound() {
+        // Arrange
+        Long activityId = 99L;
+        when(activityRepository.findById(activityId)).thenReturn(Optional.empty());
+
+        // Act and Assert
+        assertThrows(ResourceNotFoundException.class,
+                () -> activitiesService.getActivityDetail(activityId));
+        verify(activityRepository, times(1)).findById(activityId);
+        verify(workoutService, never()).getWorkout(anyLong());
+    }
+
+    @Test
+    void getActivityDetailThrowsForUnknownType() {
+        // Arrange
+        Long activityId = 1L;
+        ActivityEntity entity = createActivityEntity(1L, "Unknown");
+        entity.setId(activityId);
+        entity.setSourceId(5L);
+
+        when(activityRepository.findById(activityId)).thenReturn(Optional.of(entity));
+
+        // Act and Assert
+        assertThrows(IllegalStateException.class,
+                () -> activitiesService.getActivityDetail(activityId));
+    }
+
+    @Test
+    void addActivity() {
+        // Arrange
+        ActivityEntity entity = createActivityEntity(1L, "Workout");
+        when(activityRepository.save(entity)).thenReturn(entity);
+
+        // Act
+        activitiesService.addActivity(entity);
+
+        // Assert
+        verify(activityRepository, times(1)).save(entity);
+    }
+
+    @Test
+    void getHighlightReturnsHeaviestSet() {
+        // Arrange
+        SetEntity lightSet = new SetEntity();
+        lightSet.setSetNumber(1);
+        lightSet.setReps(10);
+        lightSet.setWeight(135);
+
+        SetEntity heavySet = new SetEntity();
+        heavySet.setSetNumber(2);
+        heavySet.setReps(5);
+        heavySet.setWeight(225);
+
+        ExerciseEntity exercise = new ExerciseEntity();
+        exercise.setTitle("Bench Press");
+        exercise.setEquipment("Barbell");
+        exercise.setDescription("Flat bench press");
+        exercise.setMuscleGroup("Chest");
+        exercise.setConcentration("Chest");
+        exercise.setIsBilateral(false);
+        exercise.setSets(List.of(lightSet, heavySet));
+
+        WorkoutEntity workout = new WorkoutEntity();
+        workout.setExercises(Set.of(exercise));
+
+        // Act
+        String highlight = activitiesService.getHighlight(workout);
+
+        // Assert
+        assertEquals("Bench Press 225x5", highlight);
+    }
+
+    @Test
+    void getHighlightReturnsEmptyForNoExercises() {
+        // Arrange
+        WorkoutEntity workout = new WorkoutEntity();
+        workout.setExercises(new HashSet<>());
+
+        // Act
+        String highlight = activitiesService.getHighlight(workout);
+
+        // Assert
+        assertEquals("", highlight);
+    }
+
+    private ActivityEntity createActivityEntity(Long memberId, String activityType) {
+        ActivityEntity entity = new ActivityEntity();
+        entity.setMemberId(memberId);
+        entity.setActivityType(activityType);
+        entity.setRoutineContext("Push Day");
+        entity.setDurationMinutes(60);
+        entity.setHighlight("Bench Press 225x5");
+        entity.setHighlightIsPR(false);
+        entity.setActivityTimestamp(OffsetDateTime.now());
+        return entity;
+    }
+
+    private ActivitySummaryDTO createSummaryDTO(Long memberId, String activityType) {
+        return new ActivitySummaryDTO(1L, memberId, 10L, activityType, "Push Day",
+                60, "Bench Press 225x5", false, OffsetDateTime.now());
+    }
+}

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
@@ -10,6 +10,7 @@ import com.robinsonir.fittrack.data.repository.member.MemberRepository;
 import com.robinsonir.fittrack.data.repository.set.SetDTO;
 import com.robinsonir.fittrack.data.repository.activities.WorkoutDTO;
 import com.robinsonir.fittrack.data.repository.workout.WorkoutRepository;
+import com.robinsonir.fittrack.data.service.activities.ActivitiesService;
 import com.robinsonir.fittrack.exception.ResourceNotFoundException;
 import com.robinsonir.fittrack.mappers.ExerciseMapper;
 import com.robinsonir.fittrack.mappers.WorkoutMapper;
@@ -45,6 +46,9 @@ public class WorkoutServiceTest {
 
     @Mock
     private ExerciseMapper exerciseMapper;
+
+    @Mock
+    private ActivitiesService activitiesService;
 
     @InjectMocks
     private WorkoutService workoutService;

--- a/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
+++ b/fit-track/src/test/java/com/robinsonir/fittrack/data/service/workout/WorkoutServiceTest.java
@@ -8,7 +8,7 @@ import com.robinsonir.fittrack.data.entity.workout.WorkoutEntity;
 import com.robinsonir.fittrack.data.repository.exercise.ExerciseDTO;
 import com.robinsonir.fittrack.data.repository.member.MemberRepository;
 import com.robinsonir.fittrack.data.repository.set.SetDTO;
-import com.robinsonir.fittrack.data.repository.workout.WorkoutDTO;
+import com.robinsonir.fittrack.data.repository.activities.WorkoutDTO;
 import com.robinsonir.fittrack.data.repository.workout.WorkoutRepository;
 import com.robinsonir.fittrack.exception.ResourceNotFoundException;
 import com.robinsonir.fittrack.mappers.ExerciseMapper;


### PR DESCRIPTION
# FTRACK-40: Unified Activity API summary list + polymorphic detail endpoint

## Description

- Introduces an Activity abstraction that provides a unified feed of all activity types with two levels of detail: a lightweight summary for the activity feed and a full polymorphic detail response per activity type.

## Changes

- **ActivityEntity** — new entity with summary fields (`memberId`, `sourceId`, `activityType`, `routineContext`, `durationMinutes`, `highlight`, `highlightIsPR`, `activityTimestamp`) mapped to `fit_tracker.activities` table
- **ActivityDetailDTO** — sealed interface with `@JsonTypeInfo`/`@JsonSubTypes` for polymorphic serialization
- **WorkoutDTO** — moved to `activities` package, implements `ActivityDetailDTO` with overrides for `activityType()`, `activityTimestamp()`, and `routineContext()`
- **ActivitySummaryDTO** — record for the summary feed shape
- **ActivityRepository** — `findByMemberId` and `findByMemberIdAndActivityType` queries
- **ActivityMapper** — MapStruct mapper for entity-to-summary conversion
- **ActivitiesService** — summary feed retrieval, polymorphic detail resolution via `activityType` + `sourceId`, highlight computation, activity creation
- **ActivitiesController** — `GET /api/v1/activities/member/{memberId}` (summary feed with optional `activityType` filter) and `GET /api/v1/activities/{activityId}` (polymorphic detail)
- **WorkoutService** — creates an `ActivityEntity` alongside each workout, wired with `@Lazy` to break circular dependency
- **Flyway migration** — `V202606152038__fit_track_add_activities_table.sql` creates the `activities` table

## Testing

- **Old behavior:** No unified activity feed existed; workouts were only accessible via the workouts endpoint.
- **New behavior:** Activities can be listed as summaries per member (with optional type filtering) and individual activity details are returned as polymorphic DTOs based on activity type.
- Added `ActivitiesServiceTest` (7 tests), `ActivityRepositoryTest` (5 tests), `ActivitiesControllerTest` (5 tests), and updated `WorkoutServiceTest` for the new dependency.
- All tests passing.

## Screenshots

<img width="1365" height="852" alt="Screenshot 2026-06-17 002519" src="https://github.com/user-attachments/assets/21f6a34d-ed82-4c8d-8494-41b9f31f7d7d" />


<img width="1373" height="855" alt="Screenshot 2026-06-17 000206" src="https://github.com/user-attachments/assets/a12b7d9b-4e71-45fa-8b9c-d73cc37e44fa" />


## Additional Comments

- `highlightIsPR` is hardcoded to `false` — PR tracking table is a separate ticket (FTRACK-42).
- Controller consolidation (removing `WorkoutController` in favor of `ActivitiesController` for all CRUD) is tracked in FTRACK-43.

# Checklist

- [x] All tests are passing
- [x] Documentation updated (if needed)
- [x] No TODOs left
- [x] Code is formatted properly